### PR TITLE
Assistant checkpoint: Enable CORS to fix config conflict

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -2,7 +2,7 @@
 headless = true
 address = "0.0.0.0"
 port = 5000
-enableCORS = false
+enableCORS = true
 enableXsrfProtection = true
 maxUploadSize = 200
 enableWebsocketCompression = true


### PR DESCRIPTION
Fix CORS/XSRF Configuration Conflict:

The .streamlit/config.toml has conflicting settings: enableCORS=false with enableXsrfProtection=true Streamlit is automatically fixing this by overriding CORS to true, but this causes a warning on every startup