### PR TITLE
Fix LCRA/LCHO dataset mix-up and TP description drift

### DIFF
--- a/analytics_refactored.py
+++ b/analytics_refactored.py
@@ -11,29 +11,18 @@ import numpy as np
 import streamlit as st
 from typing import Dict, List, Optional
 
+from tsm_measures import TP_CODES, TP_DESCRIPTIONS
+
 
 class TSMAnalytics:
     """
     Handles analytics retrieval from pre-calculated DuckDB analytics
     """
-    
+
     def __init__(self, data_processor):
         self.data_processor = data_processor  # Instance of refactored TSMDataProcessor
-        self.tp_codes = [f"TP{i:02d}" for i in range(1, 13)]
-        self.tp_descriptions = {
-            'TP01': 'Overall satisfaction',
-            'TP02': 'Satisfaction with repairs',
-            'TP03': 'Time taken to complete most recent repair',
-            'TP04': 'Satisfaction with time taken to complete most recent repair',
-            'TP05': 'Satisfaction that home is well-maintained',
-            'TP06': 'Satisfaction that home is safe',
-            'TP07': 'Satisfaction with neighbourhood',
-            'TP08': 'Satisfaction with landlord\'s contribution to neighbourhood',
-            'TP09': 'Satisfaction with approach to handling of complaints',
-            'TP10': 'Agreement that landlord treats residents fairly',
-            'TP11': 'Agreement that landlord listens to residents\' views',
-            'TP12': 'Satisfaction with landlord\'s approach to handling of anti-social behaviour'
-        }
+        self.tp_codes = list(TP_CODES)
+        self.tp_descriptions = dict(TP_DESCRIPTIONS)
     
     def calculate_rankings(self, df: pd.DataFrame, peer_group_filter: str = "All Providers", dataset_type: Optional[str] = None) -> Dict:
         """
@@ -127,9 +116,10 @@ class TSMAnalytics:
         Identifies which measures improved/declined and overall trajectory
         """
         try:
-            # Get provider data for both years
-            provider_2024 = self.data_processor.get_provider_scores(provider_code, year=2024)
-            provider_2025 = self.data_processor.get_provider_scores(provider_code, year=2025)
+            if not dataset_type:
+                dataset_type = self.data_processor.get_provider_dataset_type(provider_code)
+            provider_2024 = self.data_processor.get_provider_scores(provider_code, year=2024, dataset_type=dataset_type)
+            provider_2025 = self.data_processor.get_provider_scores(provider_code, year=2025, dataset_type=dataset_type)
             
             # Check if we have data for both years
             if provider_2024.empty or provider_2025.empty:
@@ -226,35 +216,31 @@ class TSMAnalytics:
                 'disabled': True
             }
     
-    def identify_priority(self, df: pd.DataFrame, provider_code: str) -> Dict:
+    def identify_priority(self, df: pd.DataFrame, provider_code: str, dataset_type: Optional[str] = None) -> Dict:
         """
         Identify highest-priority improvement area using pre-calculated correlations and percentiles
         """
         try:
-            # Check if provider exists
             if not self.data_processor.get_provider_exists(provider_code):
                 return {"error": f"Provider {provider_code} not found"}
-            
-            # Get provider's scores and percentiles
-            provider_scores_df = self.data_processor.get_provider_scores(provider_code)
-            provider_percentiles = self.data_processor.get_provider_percentiles(provider_code)
-            
-            if provider_scores_df.empty:
-                return {"error": "No scores found for priority analysis"}
-            
-            # Convert scores DataFrame to dict for easier access
-            provider_scores = dict(zip(provider_scores_df['tp_measure'], provider_scores_df['score']))
-            
-            # Convert percentiles DataFrame to dict for easier access
-            percentile_dict = {}
-            if not provider_percentiles.empty:
-                percentile_dict = dict(zip(provider_percentiles['tp_measure'], 
-                                          provider_percentiles['percentile_rank']))
-            
-            # Get dataset type for the provider
-            dataset_type = self.data_processor.get_provider_dataset_type(provider_code)
+
+            if not dataset_type:
+                dataset_type = self.data_processor.get_provider_dataset_type(provider_code)
             if not dataset_type:
                 dataset_type = 'LCRA'  # Default fallback
+
+            provider_scores_df = self.data_processor.get_provider_scores(provider_code, dataset_type=dataset_type)
+            provider_percentiles = self.data_processor.get_provider_percentiles(provider_code, dataset_type=dataset_type)
+
+            if provider_scores_df.empty:
+                return {"error": "No scores found for priority analysis"}
+
+            provider_scores = dict(zip(provider_scores_df['tp_measure'], provider_scores_df['score']))
+
+            percentile_dict = {}
+            if not provider_percentiles.empty:
+                percentile_dict = dict(zip(provider_percentiles['tp_measure'],
+                                          provider_percentiles['percentile_rank']))
             
             # Get pre-calculated correlations with TP01 for the specific dataset
             correlations_df = self.data_processor.get_dataset_correlations(dataset_type)
@@ -344,35 +330,36 @@ class TSMAnalytics:
         # This would require additional metadata about providers
         return df
     
-    def get_detailed_performance_analysis(self, df: pd.DataFrame, provider_code: str) -> Dict:
+    def get_detailed_performance_analysis(self, df: pd.DataFrame, provider_code: str, dataset_type: Optional[str] = None) -> Dict:
         """
-        Get detailed performance analysis using pre-calculated percentiles
+        Get detailed performance analysis using pre-calculated percentiles.
+
+        dataset_type must be passed when the provider appears in both LCRA and
+        LCHO datasets under the same provider_code (e.g. LH3827 / West Kent),
+        otherwise the scores/percentiles dicts silently collapse duplicate TP
+        codes and the UI renders the wrong dataset.
         """
         try:
-            # Check if provider exists
             if not self.data_processor.get_provider_exists(provider_code):
                 return {"error": f"Provider {provider_code} not found"}
-            
-            # Get provider's dataset type for proper peer comparison
-            dataset_type = self.data_processor.get_provider_dataset_type(provider_code)
+
+            if not dataset_type:
+                dataset_type = self.data_processor.get_provider_dataset_type(provider_code)
             if not dataset_type:
                 return {"error": "Could not determine dataset type"}
-            
-            # Get provider's scores and percentiles
-            provider_scores_df = self.data_processor.get_provider_scores(provider_code)
-            
+
+            provider_scores_df = self.data_processor.get_provider_scores(provider_code, dataset_type=dataset_type)
+
             if provider_scores_df is None or provider_scores_df.empty:
                 return {"error": "No scores found for this provider"}
-            
-            # Convert scores DataFrame to dict
+
             provider_scores = dict(zip(provider_scores_df['tp_measure'], provider_scores_df['score']))
-            
-            provider_percentiles = self.data_processor.get_provider_percentiles(provider_code)
-            
-            # Convert percentiles DataFrame to dict
+
+            provider_percentiles = self.data_processor.get_provider_percentiles(provider_code, dataset_type=dataset_type)
+
             percentile_dict = {}
             if provider_percentiles is not None and not provider_percentiles.empty:
-                percentile_dict = dict(zip(provider_percentiles['tp_measure'], 
+                percentile_dict = dict(zip(provider_percentiles['tp_measure'],
                                           provider_percentiles['percentile_rank']))
             
             detailed_analysis = {}

--- a/app.py
+++ b/app.py
@@ -12,6 +12,7 @@ from mobile_utils import detect_mobile, mobile_friendly_columns, render_mobile_i
 import traceback
 from contextlib import contextmanager
 from config import DB_PATH
+from tsm_measures import LCHO_EXCLUDED
 import os
 
 # Page configuration - MUST be first Streamlit command
@@ -368,14 +369,14 @@ def main():
 
         # Calculate key metrics using pre-calculated data within the correct peer group
         rankings = analytics.calculate_rankings(df, "All Providers", dataset_type)
-        momentum = analytics.calculate_momentum(df, provider_code)
+        momentum = analytics.calculate_momentum(df, provider_code, dataset_type=dataset_type)
 
         # Get dataset-specific correlations for priority calculation
         if dataset_type == 'LCHO':
             correlations_df = data_processor.get_dataset_correlations('LCHO')
         else:
             correlations_df = data_processor.get_dataset_correlations('LCRA')
-        priority = analytics.identify_priority(df, provider_code)
+        priority = analytics.identify_priority(df, provider_code, dataset_type=dataset_type)
 
         # Initialize and render dashboard
         dashboard = ExecutiveDashboard()
@@ -410,7 +411,7 @@ def main():
                     """)
 
                 detailed_analysis = analytics.get_detailed_performance_analysis(
-                    df, provider_code)
+                    df, provider_code, dataset_type=dataset_type)
 
                 # Debug logging
                 if show_advanced_logging:
@@ -423,8 +424,8 @@ def main():
                 if dataset_type == 'LCHO' and detailed_analysis and "error" not in detailed_analysis:
                     original_count = len(detailed_analysis)
                     detailed_analysis = {
-                        k: v for k, v in detailed_analysis.items() 
-                        if k not in ['TP02', 'TP03', 'TP04']
+                        k: v for k, v in detailed_analysis.items()
+                        if k not in LCHO_EXCLUDED
                     }
                     if show_advanced_logging:
                         st.write(f"Debug - Filtered {original_count} measures down to {len(detailed_analysis)} for LCHO")
@@ -456,7 +457,7 @@ def main():
                 # Filter priority matrix for LCHO if needed
                 if dataset_type == 'LCHO' and priority:
                     # Ensure repairs metrics aren't in the priority recommendations
-                    if 'measure' in priority and priority['measure'] in ['TP02', 'TP03', 'TP04']:
+                    if 'measure' in priority and priority['measure'] in LCHO_EXCLUDED:
                         st.warning("Priority calculation adjusted for LCHO dataset")
 
                 dashboard.render_priority_matrix(priority, detailed_analysis)
@@ -464,12 +465,7 @@ def main():
             with st.expander("📋 Raw Data", expanded=False):
                 st.markdown(f"### Raw Data - {dataset_type} Provider")
 
-                # Show provider's raw scores - FILTERED BY DATASET TYPE
-                scores_df = data_processor.get_provider_scores(provider_code)
-                
-                # Filter to only show the selected dataset type to avoid confusion
-                if not scores_df.empty and 'dataset_type' in scores_df.columns:
-                    scores_df = scores_df[scores_df['dataset_type'] == dataset_type]
+                scores_df = data_processor.get_provider_scores(provider_code, dataset_type=dataset_type)
                 
                 if not scores_df.empty:
                     # Ensure scores_df is a DataFrame, not an array
@@ -477,13 +473,10 @@ def main():
                         # Add descriptions
                         scores_df['description'] = scores_df['tp_measure'].apply(lambda x: data_processor.tp_descriptions.get(x, 'Unknown measure'))
 
-                        # Filter out non-applicable measures based on dataset type
                         if dataset_type == 'LCHO':
-                            # Remove repairs metrics (TP02-TP04) for LCHO providers
-                            na_metrics = ['TP02', 'TP03', 'TP04']
-                            scores_df = scores_df[~scores_df['tp_measure'].isin(na_metrics)]
+                            scores_df = scores_df[~scores_df['tp_measure'].isin(LCHO_EXCLUDED)]
 
-                            st.info("ℹ️ **Note**: Repairs metrics (TP02-TP04) are not applicable to LCHO providers and are excluded from this view.")
+                            st.info("ℹ️ **Note**: Measures TP02-TP04 (repairs and home-maintenance) are not applicable to LCHO providers and are excluded from this view.")
 
                         # Format for display
                         display_df = scores_df[['tp_measure', 'description', 'score']].copy()

--- a/dashboard.py
+++ b/dashboard.py
@@ -943,7 +943,7 @@ class ExecutiveDashboard:
             for tp_code, data in detailed_analysis.items():
                 table_data.append({
                     'Measure': tp_code,
-                    'Description': data['description'][:40] + '...' if len(data['description']) > 40 else data['description'],
+                    'Description': data['description'],
                     'Your Score': f"{data['score']:.1f}",
                     'Percentile': f"{data['percentile']:.1f}%",
                     'Peer Avg': f"{data['peer_avg']:.1f}"

--- a/data_processor_enhanced.py
+++ b/data_processor_enhanced.py
@@ -12,34 +12,19 @@ import duckdb
 import numpy as np
 from typing import Optional, Dict, List, Tuple
 from config import DB_PATH
+from tsm_measures import TP_CODES, TP_DESCRIPTIONS, LCHO_EXCLUDED
 
 
 class EnhancedTSMDataProcessor:
     """Enhanced processor for TSM data with dataset isolation"""
 
     def __init__(self, silent_mode=False):
-        self.tp_codes = [f"TP{i:02d}" for i in range(1, 13)]  # TP01 to TP12
-        # Updated to use the new enhanced database
+        self.tp_codes = list(TP_CODES)
+        self.tp_descriptions = dict(TP_DESCRIPTIONS)
         self.db_path = DB_PATH
         self.silent_mode = silent_mode
         self._connection = None
         self._connect_to_db()
-
-        # TP measure descriptions
-        self.tp_descriptions = {
-            'TP01': 'Overall satisfaction',
-            'TP02': 'Satisfaction with repairs',
-            'TP03': 'Time taken to complete repair',
-            'TP04': 'Satisfaction with time taken',
-            'TP05': 'Home well-maintained',
-            'TP06': 'Home is safe',
-            'TP07': 'Listens to views',
-            'TP08': 'Keeps informed',
-            'TP09': 'Treats fairly',
-            'TP10': 'Complaints handling',
-            'TP11': 'Communal areas clean',
-            'TP12': 'Anti-social behaviour'
-        }
 
     def _connect_to_db(self):
         """Connect to the enhanced DuckDB database"""
@@ -123,34 +108,34 @@ class EnhancedTSMDataProcessor:
             self._log_error(f"Error fetching dataset type: {str(e)}")
             return None
 
-    def get_provider_percentiles(self, provider_code: str, year: int = 2025) -> pd.DataFrame:
+    def get_provider_percentiles(self, provider_code: str, year: int = 2025, dataset_type: Optional[str] = None) -> pd.DataFrame:
         """
         Get pre-calculated percentile ranks for a specific provider
-        Within their appropriate peer group (LCRA or LCHO)
-        Defaults to year 2025 (latest data)
+        within their appropriate peer group (LCRA or LCHO).
+
+        When the provider is listed under both datasets, pass dataset_type to
+        filter the correct peer group.
         """
         self._ensure_connection()
         if not self._connection:
             return pd.DataFrame()
 
-        # First get the provider's dataset type
-        dataset_type = self.get_provider_dataset_type(provider_code)
-        if not dataset_type:
-            self._log_error(f"Could not determine dataset type for provider {provider_code}")
-            return pd.DataFrame()
-
         query = """
-        SELECT 
-            tp_measure, 
+        SELECT
+            tp_measure,
             percentile_rank,
             peer_group_size,
             dataset_type
-        FROM calculated_percentiles 
+        FROM calculated_percentiles
         WHERE provider_code = ? AND year = ?
         """
+        params: List = [provider_code, year]
+        if dataset_type:
+            query += " AND dataset_type = ?"
+            params.append(dataset_type)
 
         try:
-            result = self._connection.execute(query, [provider_code, year]).df()
+            result = self._connection.execute(query, params).df()
             return result
         except Exception as e:
             self._log_error(f"Error fetching percentiles: {str(e)}")
@@ -245,17 +230,19 @@ class EnhancedTSMDataProcessor:
 
         return options
 
-    def get_provider_scores(self, provider_code: str, year: int = 2025) -> pd.DataFrame:
+    def get_provider_scores(self, provider_code: str, year: int = 2025, dataset_type: Optional[str] = None) -> pd.DataFrame:
         """
-        Get raw scores for a specific provider for a given year
-        Defaults to 2025 (latest year)
+        Get raw scores for a specific provider for a given year.
+
+        When the provider exists in both LCRA and LCHO datasets under the same
+        provider_code, pass dataset_type to isolate the correct peer group.
         """
         self._ensure_connection()
         if not self._connection:
             return pd.DataFrame()
 
         query = """
-        SELECT 
+        SELECT
             tp_measure,
             score,
             dataset_type,
@@ -263,9 +250,13 @@ class EnhancedTSMDataProcessor:
         FROM raw_scores
         WHERE provider_code = ? AND year = ?
         """
+        params: List = [provider_code, year]
+        if dataset_type:
+            query += " AND dataset_type = ?"
+            params.append(dataset_type)
 
         try:
-            result = self._connection.execute(query, [provider_code, year]).df()
+            result = self._connection.execute(query, params).df()
             return result
         except Exception as e:
             self._log_error(f"Error fetching provider scores: {str(e)}")
@@ -438,7 +429,7 @@ class EnhancedTSMDataProcessor:
         LCHO doesn't have TP02-TP04 (repairs metrics)
         """
         if dataset_type == 'LCHO':
-            return [tp for tp in self.tp_codes if tp not in ['TP02', 'TP03', 'TP04']]
+            return [tp for tp in self.tp_codes if tp not in LCHO_EXCLUDED]
         else:
             return self.tp_codes
 

--- a/tooltip_definitions.py
+++ b/tooltip_definitions.py
@@ -169,17 +169,17 @@ class TooltipDefinitions:
                 
                 **The 12 measures:**
                 • **TP01**: Overall satisfaction (primary measure)
-                • **TP02**: Satisfaction with repairs
-                • **TP03**: Time taken for recent repair
-                • **TP04**: Satisfaction with repair time
-                • **TP05**: Home is well-maintained
-                • **TP06**: Home is safe
-                • **TP07**: Satisfaction with neighbourhood
-                • **TP08**: Landlord's neighbourhood contribution
-                • **TP09**: Complaint handling approach
-                • **TP10**: Landlord treats residents fairly
-                • **TP11**: Landlord listens to residents
-                • **TP12**: Anti-social behaviour handling
+                • **TP02**: Satisfaction with the overall repairs service
+                • **TP03**: Satisfaction with the time taken to complete most recent repair
+                • **TP04**: Satisfaction that the home is well maintained
+                • **TP05**: Satisfaction that the home is safe
+                • **TP06**: Landlord listens to tenant views and acts upon them
+                • **TP07**: Landlord keeps tenants informed
+                • **TP08**: Landlord treats tenants fairly and with respect
+                • **TP09**: Landlord's approach to complaints handling
+                • **TP10**: Communal areas kept clean and well maintained
+                • **TP11**: Landlord makes a positive contribution to the neighbourhood
+                • **TP12**: Landlord's approach to handling anti-social behaviour
                 """
             },
             'peer_comparison': {

--- a/tsm_measures.py
+++ b/tsm_measures.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025-2026 Tom Stephenson (Teev-dev)
+
+"""
+TSM measure constants.
+
+Single source of truth for the twelve Tenant Satisfaction Measures (TP01-TP12)
+published by the UK Regulator of Social Housing. Descriptions here are taken
+verbatim (shortened) from the regulator's 2025 column headers in
+TSM25_LCRA_Perception / TSM25_LCHO_Perception.
+
+LCHO providers do not report TP02-TP04 (repairs and home-maintenance measures
+that do not apply to low-cost home ownership).
+"""
+
+from typing import Dict, List, Set
+
+
+TP_CODES: List[str] = [f"TP{i:02d}" for i in range(1, 13)]
+
+TP_DESCRIPTIONS: Dict[str, str] = {
+    "TP01": "Overall satisfaction with the service",
+    "TP02": "Satisfaction with the overall repairs service",
+    "TP03": "Satisfaction with the time taken to complete most recent repair",
+    "TP04": "Satisfaction that the home is well maintained",
+    "TP05": "Satisfaction that the home is safe",
+    "TP06": "Satisfaction that the landlord listens to tenant views and acts upon them",
+    "TP07": "Satisfaction that the landlord keeps tenants informed",
+    "TP08": "Agreement that the landlord treats tenants fairly and with respect",
+    "TP09": "Satisfaction with the landlord's approach to complaints handling",
+    "TP10": "Satisfaction that communal areas are kept clean and well maintained",
+    "TP11": "Satisfaction that the landlord makes a positive contribution to the neighbourhood",
+    "TP12": "Satisfaction with the landlord's approach to handling anti-social behaviour",
+}
+
+LCHO_EXCLUDED: Set[str] = {"TP02", "TP03", "TP04"}
+
+
+def applicable_measures(dataset_type: str) -> List[str]:
+    """Return TP codes that apply to the given dataset type (LCRA or LCHO)."""
+    if dataset_type == "LCHO":
+        return [tp for tp in TP_CODES if tp not in LCHO_EXCLUDED]
+    return list(TP_CODES)


### PR DESCRIPTION
## Summary

- **Bug:** Providers listed in both LCRA and LCHO datasets under the same `provider_code` (e.g. West Kent / `LH3827`) were silently rendering the wrong dataset's scores on the Detailed Scores, Priority Matrix and Performance Analysis panels. Root cause was a missing `dataset_type` filter in `get_provider_scores` / `get_provider_percentiles`; the returned DataFrame contained rows for both datasets, which then collapsed via `dict(zip(tp_measure, score))` — duplicate keys silently kept the last-returned value.
- **Fix:** Thread `dataset_type` through the read path. `app.py` resolves it once from the provider-name suffix and passes it into `get_detailed_performance_analysis`, `calculate_momentum`, `identify_priority`, which push it down to SQL (`AND dataset_type = ?`).
- **Related fix:** TP07–TP12 labels on the Raw Data panel were wrong (e.g. TP09 shown as "Treats fairly" — TP09 is Complaints Handling). Consolidated three conflicting description dictionaries into a new `tsm_measures.py` domain-constants module sourced from the 2025 regulator xlsx column headers.
- **UI:** Removed the hardcoded 40-char truncation on the Detailed Scores description column so RSH-standard wording is shown in full.

## Verification

Ground-truthed against `TSM25_LCRA_Perception` row 245 (West Kent):

| Measure | Regulator xlsx | Pre-fix Detailed Scores | Post-fix Detailed Scores |
|---|---|---|---|
| TP01 | 74.5 | 58.5 (LCHO) | 74.5 ✓ |
| TP09 | 37.0 | 29.4 (LCHO) | 37.0 ✓ |
| TP12 | 58.2 | 44.5 (LCHO) | 58.2 ✓ |

LCHO isolation also verified (LH3827 LCHO returns 58.5 / 29.4 / 44.5). LCRA-only provider regression unchanged.

## Test plan

- [ ] Open West Kent (LH3827) in the app — Detailed Scores, Raw Data and Priority Matrix all show LCRA values (74.5 / 37.0 / 58.2) with regulator-accurate descriptions
- [ ] Spot-check an LCHO-only provider — TP02–TP04 excluded, correct scores shown
- [ ] Spot-check an LCRA-only provider — unchanged from pre-fix
- [ ] Detailed Scores description column wraps the full RSH wording, no ellipsis
- [ ] Railway deploy preview boots cleanly

## Notes

- DB was not rebuilt — values in `raw_scores` / `calculated_percentiles` were always correct; only the Python read path and label source changed.
- No ETL changes; ADR not required.

Generated with Claude Code