### PR TITLE
Add tsm_measures.py to Dockerfile COPY list

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN pip install --no-cache-dir . && rm -rf /root/.cache
 
 # Copy application code
 COPY app.py dashboard.py analytics_refactored.py data_processor_enhanced.py \
-     styles.py tooltip_definitions.py mobile_utils.py config.py ./
+     styles.py tooltip_definitions.py mobile_utils.py config.py tsm_measures.py ./
 COPY pages/ pages/
 COPY .streamlit/ .streamlit/
 


### PR DESCRIPTION
Hotfix for production deploy failure after #14.

The Dockerfile uses an explicit file list for the application COPY step. The new \`tsm_measures.py\` module was not added, so the container started without it and Streamlit crashed on import:

\`\`\`
ModuleNotFoundError: No module named 'tsm_measures'
  File "/app/data_processor_enhanced.py", line 15, in <module>
    from tsm_measures import TP_CODES, TP_DESCRIPTIONS, LCHO_EXCLUDED
\`\`\`

One-line fix: add \`tsm_measures.py\` to the COPY list.

## Test plan

- [ ] Railway build succeeds
- [ ] App loads on production URL
- [ ] West Kent (LH3827, LCRA) still shows TP01=74.5 / TP09=37.0 with correct descriptions

Generated with Claude Code