### PR TITLE
Harden Docker image (allowlist .dockerignore) + add gitleaks pre-commit

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,52 +1,35 @@
-# Git
-.git/
-.gitignore
+# Allowlist .dockerignore: everything is excluded unless explicitly re-included.
+# Adding a new file to the repo does NOT automatically ship it to production.
+# When adding a new runtime file, add an explicit `!path` line here.
 
-# Source data (not needed at runtime)
-data/source/
-data/docs/
-data/hailie_analytics.duckdb
+# Exclude everything by default
+**
 
-# Documentation (keep README.md for pyproject.toml)
+# --- Runtime Python modules (top level) ---
+!app.py
+!dashboard.py
+!analytics_refactored.py
+!data_processor_enhanced.py
+!styles.py
+!tooltip_definitions.py
+!mobile_utils.py
+!config.py
+!tsm_measures.py
+
+# --- Package metadata (required by `pip install .`) ---
+!pyproject.toml
 !README.md
-CLAUDE.md
-MASTERPLAN.md
-FEATURES_ROADMAP.md
-DEPLOYMENT.md
-MAINTENANCE.md
-HANDOFF.md
-HAILIE-Insights-Engine-Architecture-v2.md
-LICENSE-CODE
-LICENSE-DOCS
-ADRs/
-guides/
 
-# Development & build tools
-build_analytics_db.py
-build_analytics_db_v2.py
-db_view_script.py
-diagnose_duplicates.py
-review_pvalues.py
+# --- Streamlit assets ---
+!pages/
+!pages/**/*.py
+!.streamlit/
+!.streamlit/**/*.toml
 
-# Python artifacts
-__pycache__/
-*.py[cod]
-*.egg-info/
+# --- Baked-in default analytics database ---
+# Source xlsx files, docs, and the legacy duckdb stay excluded by default
+!data/
+!data/hailie_analytics_v2.duckdb
 
-# Environment
-.env
-.env.*
-.venv/
-
-# OS & IDE
-.DS_Store
-.idea/
-.vscode/
-
-# Replit (legacy)
-.replit
-replit.md
-
-# Docker
-Dockerfile
-.dockerignore
+# --- Container entrypoint ---
+!entrypoint.sh

--- a/.dockerignore
+++ b/.dockerignore
@@ -21,14 +21,14 @@
 !README.md
 
 # --- Streamlit assets ---
-!pages/
+# Re-include the specific files only — do NOT un-ignore the whole directory
+# (that would re-include any future siblings by default).
 !pages/**/*.py
-!.streamlit/
 !.streamlit/**/*.toml
 
 # --- Baked-in default analytics database ---
-# Source xlsx files, docs, and the legacy duckdb stay excluded by default
-!data/
+# Source xlsx files, docs, and the legacy duckdb stay excluded by default.
+# Re-include ONLY the specific DB file; do NOT un-ignore data/ as a whole.
 !data/hailie_analytics_v2.duckdb
 
 # --- Container entrypoint ---

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+# Pre-commit hooks. Install once per clone:
+#   pip install pre-commit && pre-commit install
+#
+# Runs gitleaks on staged content before each commit to catch API keys,
+# tokens, private keys and other high-risk secrets. If a false positive
+# fires, add an allowlist rule to .gitleaks.toml rather than bypassing
+# the hook with --no-verify.
+
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.18.4
+    hooks:
+      - id: gitleaks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,17 +83,31 @@ st.markdown(f"<span>{html.escape(measure_desc)}</span>", unsafe_allow_html=True)
 
 ### LCRA vs LCHO isolation — CRITICAL
 
-Never mix provider types in peer comparisons. All ranking and percentile methods take `dataset_type` — always pass it.
+Never mix provider types in peer comparisons. All ranking and percentile methods take `dataset_type` — always pass it explicitly from the call site. Providers can exist in both datasets under the same `provider_code` (e.g. West Kent / LH3827); if `dataset_type` is omitted, `get_provider_scores` / `get_provider_percentiles` return rows for both, and any downstream `dict(zip(tp_measure, score))` silently collapses duplicates to the last-returned dataset — a correctness bug with no warning.
 
 ```python
-# WRONG — compares rental providers against home ownership providers
-percentiles = processor.get_provider_percentiles(code, year=2025)
+# WRONG — may return rows for both datasets; dict collapse picks the wrong one
+scores = processor.get_provider_scores(provider_code)
 
-# RIGHT — isolated within provider's own peer group
-dataset_type = processor.get_provider_dataset_type(code)
-percentiles = processor.get_provider_percentiles(code, year=2025)
-# dataset_type is determined automatically and used for peer isolation
+# RIGHT — SQL filters to the caller's known dataset
+scores = processor.get_provider_scores(provider_code, dataset_type=dataset_type)
 ```
+
+### Docker image contents — CRITICAL
+
+`.dockerignore` is **allowlist-shaped**: everything in the repo is excluded from the build context unless explicitly re-included with a `!path` line. Adding a new file does **not** ship it to production by default — you must opt it in. This prevents accidental leaks of docs, credentials, scratch files, or dev scripts.
+
+When adding a new runtime module, add an explicit `!path` entry to `.dockerignore`. Verify with `docker build -t hailie-insights . && docker run --rm hailie-insights find /app -type f` before merging.
+
+### Secret scanning — CRITICAL
+
+`pre-commit` with the `gitleaks` hook runs on every commit. Install once per clone:
+
+```bash
+pip install pre-commit && pre-commit install
+```
+
+Never bypass the hook with `--no-verify` to ship a suspected secret. If gitleaks fires on a legitimate false positive, add an allowlist rule to `.gitleaks.toml` — do not suppress the hook.
 
 ### No PII logging — CRITICAL
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,18 +10,11 @@ WORKDIR /app
 COPY pyproject.toml README.md ./
 RUN pip install --no-cache-dir . && rm -rf /root/.cache
 
-# Copy application code
-COPY app.py dashboard.py analytics_refactored.py data_processor_enhanced.py \
-     styles.py tooltip_definitions.py mobile_utils.py config.py tsm_measures.py ./
-COPY pages/ pages/
-COPY .streamlit/ .streamlit/
+# Copy application code. The build context is filtered by .dockerignore
+# (allowlist-shaped: everything excluded unless explicitly re-included), so
+# this COPY ships only the files enumerated there.
+COPY . .
 
-# Copy pre-built analytics database (open-source default)
-# Production deployments can override with DATA_PATH env var pointing to a persistent volume
-COPY data/hailie_analytics_v2.duckdb data/
-
-# Copy entrypoint and set ownership
-COPY entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh && chown -R hailie:hailie /app
 
 # Health check


### PR DESCRIPTION
## Summary

Defence-in-depth against two classes of mistake that each bit us once already:

1. **Missing runtime file in container** (#15) — new module added but not in the Dockerfile's explicit `COPY` list, production deploy crashed on import.
2. **Accidental doc / credential leak** — blocklist-shaped \`.dockerignore\` lets any new file ship unless someone remembers to exclude it.

### What changed

- **\`.dockerignore\`**: now allowlist-shaped. Everything in the repo is excluded from the build context unless explicitly re-included with a \`!path\` line. Adding a new file is now fail-safe — it simply won't ship until you opt it in.
- **\`Dockerfile\`**: simplified to \`COPY . .\` — the build context filter lives in one place (\`.dockerignore\`). No more drift between the two.
- **\`.pre-commit-config.yaml\`**: new — runs \`gitleaks\` on every commit to block API keys, tokens, private keys. Install once per clone: \`pip install pre-commit && pre-commit install\`.
- **\`CLAUDE.md\`**: documents both guardrails and sharpens the LCRA/LCHO rule to reflect what the fix in #14 actually taught us (dict-collapse silent bug).

### Verified

Simulated the allowlist against the working tree:
- **16 files shipped** (all 9 runtime \`.py\` modules, \`pyproject.toml\`, \`README.md\`, \`entrypoint.sh\`, \`pages/privacy_policy.py\`, two \`.streamlit\` configs, baked-in DB)
- **34 files excluded** (ADRs, HANDOFF, CLAUDE.md, Dockerfile itself, \`.claude/\` settings, \`data/source/\` xlsx files, dev scripts like \`build_analytics_db*.py\`)
- **No suspicious exclusions** (no \`.env\`, no credentials, no private keys — because we never committed any)

Local \`docker build\` could not run (daemon not available in this session) — recommend verifying the Railway build log before this lands.

## Note

CLAUDE.md is flagged as a governance doc in its own \"never do\" table. Edit was explicitly requested by project owner.

## Test plan

- [ ] Railway build succeeds on this branch preview
- [ ] Production URL loads after merge
- [ ] \`docker run --rm <image> find /app -type f\` contains only the 16 allowlisted files
- [ ] \`pre-commit install\` + a test commit with a fake AWS key is blocked

## Future TODO

CI workflow required by branch protection that runs \`docker build\`, boots the container, asserts import correctness. Deferred — noted as low-priority until PR volume justifies the maintenance cost.

Generated with Claude Code