### PR TITLE
docs: Update documentation with custom domain URL

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -34,7 +34,7 @@
 - [x] Railway project: extraordinary-trust
 - [x] Branch: migration/railway (temporary, for testing before merge to main)
 - [x] Volume mounted at /data with DATA_PATH=/data
-- [x] Public URL: https://hailieinsightsengine-production.up.railway.app
+- [x] Public URL: https://insights.housingai.org
 - [x] Auto-seed working (config.py copies baked-in DB to volume on first deploy)
 - [x] App loads and functions correctly
 
@@ -72,7 +72,7 @@ Check the public URL — the "double_arrow_right" text at top should be gone.
 | Owner | Tom Stephenson (Teev-dev) |
 | License | Dual: MIT (code), CC-BY 4.0 (docs/data) |
 | Railway project | extraordinary-trust |
-| Public URL | hailieinsightsengine-production.up.railway.app |
+| Public URL | insights.housingai.org |
 | Volume mount | /data (DATA_PATH=/data) |
 | Current branch on Railway | migration/railway |
 | Production branch | main (switch back after merge) |

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Streamlit web application that transforms UK government TSM (Tenant Satisfaction Measures) data into actionable executive insights for social housing providers.
 
+**Live:** https://insights.housingai.org
+
 ## Overview
 
 HAILIE Insights Engine delivers instant analytics from pre-processed TSM 2024-2025 government data, supporting both LCRA (Low Cost Rental Accommodation) and LCHO (Low Cost Home Ownership) providers with dataset-specific peer comparisons.


### PR DESCRIPTION
## Summary

- Replace references to \`*.up.railway.app\` with the custom domain \`insights.housingai.org\`
- Adds live URL to README
- Updates HANDOFF.md public URL references

The custom domain was added to Railway with a dedicated Let's Encrypt cert. The \`*.up.railway.app\` subdomain was being flagged by some network SSL inspection filters (e.g. Cisco Umbrella on public wifi), which was impacting user trust.

## Test plan

- [x] https://insights.housingai.org loads correctly on mobile data
- [x] Valid Let's Encrypt certificate served (no SSL warnings on unmanaged networks)
- [x] App functionality unchanged — same codebase, just new URL

Generated with Claude Code