### PR TITLE
Document pre-commit hook setup in README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,10 +101,12 @@ When adding a new runtime module, add an explicit `!path` entry to `.dockerignor
 
 ### Secret scanning — CRITICAL
 
-`pre-commit` with the `gitleaks` hook runs on every commit. Install once per clone:
+`pre-commit` with the `gitleaks` hook runs on every commit. Install once per clone — see [README.md](README.md#pre-commit-hooks-one-time-setup-per-clone) for the full setup (including the venv PATH caveat). The short version:
 
 ```bash
-pip install pre-commit && pre-commit install
+source .venv/bin/activate
+pip install pre-commit
+pre-commit install
 ```
 
 Never bypass the hook with `--no-verify` to ship a suspected secret. If gitleaks fires on a legitimate false positive, add an allowlist rule to `.gitleaks.toml` — do not suppress the hook.

--- a/README.md
+++ b/README.md
@@ -26,9 +26,28 @@ HAILIE Insights Engine delivers instant analytics from pre-processed TSM 2024-20
 ```bash
 git clone https://github.com/Teev-dev/HAILIE_Insights_Engine.git
 cd HAILIE_Insights_Engine
+python -m venv .venv && source .venv/bin/activate
 pip install .
 streamlit run app.py
 ```
+
+### Pre-commit hooks (one-time setup per clone)
+
+This repo uses [pre-commit](https://pre-commit.com/) with [gitleaks](https://github.com/gitleaks/gitleaks) to block accidental commits of API keys, tokens, and private keys. Install once after cloning:
+
+```bash
+source .venv/bin/activate           # if not already active
+pip install pre-commit
+pre-commit install                  # wires the hook into .git/hooks/pre-commit
+pre-commit run --all-files          # optional: scan the whole repo now
+```
+
+From this point on, `git commit` runs gitleaks automatically on staged content.
+
+**Notes:**
+- If you install `pre-commit` inside the project venv (recommended), the `pre-commit` command is only on PATH when the venv is activated. For a global install, use `brew install pre-commit` on macOS.
+- If a genuine false positive fires, add an allowlist rule to `.gitleaks.toml` — never bypass the hook with `git commit --no-verify`.
+- If you delete and recreate the venv, re-run `pre-commit install`.
 
 ### Docker
 


### PR DESCRIPTION
## Summary

Adds a 'Pre-commit hooks' section to README.md covering:
- Full setup sequence (activate venv → \`pip install pre-commit\` → \`pre-commit install\`)
- The venv-PATH gotcha (\`pre-commit: command not found\` when venv not activated)
- Global-install alternative via Homebrew
- Guidance on false-positive handling and hook re-install after venv recreation

Also updates CLAUDE.md's existing 'Secret scanning' section to reflect this reality — previously it just said \`pip install pre-commit && pre-commit install\` with no mention of the venv caveat, which I hit myself when setting this up.

No code changes.

## Test plan

- [ ] README renders correctly on GitHub
- [ ] Cross-reference link in CLAUDE.md resolves to the README section

Generated with Claude Code