### PR TITLE
feat(config): CURRENT_DATA_YEAR constant for user-facing year labels (from PR #12)

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,6 +15,11 @@ from config import DB_PATH
 from tsm_measures import LCHO_EXCLUDED
 import os
 
+# User-facing year label for the currently-loaded TSM dataset.
+# Query-layer year defaults (data_processor_enhanced.py, analytics_refactored.py)
+# are updated separately per MAINTENANCE.md — do not point them at this constant.
+CURRENT_DATA_YEAR = 2025
+
 # Page configuration - MUST be first Streamlit command
 # Using 'wide' layout for all devices, content adapts responsively
 st.set_page_config(
@@ -267,7 +272,7 @@ def main():
 
         # Note about the enhanced architecture
         st.markdown("---")
-        st.info("""
+        st.info(f"""
         📊 **Enhanced Analytics Engine**
 
         This application uses an enhanced analytics database with:
@@ -276,7 +281,7 @@ def main():
         • Peer group isolation
         • Automatic metric adaptation
 
-        Data source: 2025 TSM Dataset
+        Data source: {CURRENT_DATA_YEAR} TSM Dataset
         """)
 
     st.markdown('<div id="provider-search-section"></div>', unsafe_allow_html=True)
@@ -503,7 +508,7 @@ def main():
         # Footer
         st.markdown("---")
         st.caption(
-            f"HAILIE TSM Insights Engine v3.0 | Enhanced Analytics with {dataset_type} Dataset | Data: 2025 TSM"
+            f"HAILIE TSM Insights Engine v3.0 | Enhanced Analytics with {dataset_type} Dataset | Data: {CURRENT_DATA_YEAR} TSM"
         )
         st.markdown(
             '<p style="text-align: center; font-size: 0.8em; color: #94A3B8; margin: 0.25rem 0;">'
@@ -534,7 +539,7 @@ def main():
         
         # Footer with privacy link
         st.markdown("---")
-        st.caption("HAILIE TSM Insights Engine v3.0 | Data: 2025 TSM")
+        st.caption(f"HAILIE TSM Insights Engine v3.0 | Data: {CURRENT_DATA_YEAR} TSM")
         st.markdown(
             '<p style="text-align: center; font-size: 0.8em; color: #94A3B8; margin: 0.25rem 0;">'
             '&copy; 2026 Tom Stephenson (Teev-dev). Built for HAILIE. '


### PR DESCRIPTION
## Summary

Introduces a single `CURRENT_DATA_YEAR = 2025` module-level constant in `app.py` and routes the three user-facing \"2025\" display strings through it. Annual TSM data updates still follow `MAINTENANCE.md`; this just removes three places from the list.

Cherry-picked from PR #12 with a bug fix — PR #12's original version would have rendered `\"Data source: {CURRENT_DATA_YEAR} TSM Dataset\"` literally because the enclosing `st.info(\"\"\"...\"\"\")` was a regular triple-quoted string, not an f-string. Converted to f-string here.

## Changes

| Location | Before | After |
|---|---|---|
| `app.py:17-21` | — | New `CURRENT_DATA_YEAR = 2025` constant with scope-limiting comment |
| `app.py:274` | `st.info(\"\"\"… Data source: 2025 TSM Dataset …\"\"\")` | `st.info(f\"\"\"… Data source: {CURRENT_DATA_YEAR} TSM Dataset …\"\"\")` |
| `app.py:510` | `f\"… Data: 2025 TSM\"` | `f\"… Data: {CURRENT_DATA_YEAR} TSM\"` |
| `app.py:541` | `st.caption(\"… Data: 2025 TSM\")` | `st.caption(f\"… Data: {CURRENT_DATA_YEAR} TSM\")` |

## Deliberately out of scope

- **Query-layer year defaults** (e.g. `data_processor_enhanced.py` `year=2025` params × ~10, the hardcoded SQL at `data_processor_enhanced.py:461`, `analytics_refactored.py:129`). These have different update semantics and are tracked in `MAINTENANCE.md` for the annual refresh. Pointing them at this constant would silently couple distinct concerns.
- **Momentum labels** in `dashboard.py` (five \"2025 vs 2024\" references at lines 184, 190, 227, 874 and similar). These need a `CURRENT_DATA_YEAR - 1` concept which PR #12 didn't introduce. Suggest a follow-up if desired, tracked outside this PR.

## Context

Second cherry-pick from the PR #12 rescue plan (Group B in `HANDOFF.md`). Developed in a `git worktree` off latest `main` per the autonomous-session protocol.

## Test plan

- [x] `python3 -c \"import ast; ast.parse(open('app.py').read())\"` — parses
- [x] Only user-facing 2025 strings in `app.py` are the new constant definition and copyright line
- [x] Gitleaks pre-commit hook passed
- [ ] **Manual verification (please do before merging):** `streamlit run app.py`
  - Confirm sidebar \"Enhanced Analytics Engine\" info block shows \"Data source: 2025 TSM Dataset\" (not literal \"{CURRENT_DATA_YEAR}\")
  - Confirm footer on provider page shows \"Data: 2025 TSM\"
  - Confirm footer on \"no provider selected\" state shows \"Data: 2025 TSM\"

Generated with Claude Code