### PR TITLE
feat(ui): dismissible 'What's new' changelog toast (from PR #12)

### DIFF
--- a/app.py
+++ b/app.py
@@ -369,6 +369,7 @@ def main():
             with st.container():
                 st.info("""
                 🆕 **What's new** — thanks for the feedback. We've:
+                - TSM Insights by HAILIE is fully open-source! Your organisation can use, copy, and build on everything here free of charge in line with the MIT license for code, and the CC-BY 4.0 license for everything else.
                 - Fixed some measure descriptions that were showing the wrong name
                 - Renamed "Raw Data" to "Score Breakdown" (same thing, clearer name)
                 - Given the Priority Matrix friendlier labels to show where to focus first

--- a/app.py
+++ b/app.py
@@ -361,6 +361,23 @@ def main():
 
         st.success(f"✅ Loaded {dataset_type} analytics for provider: {provider_code}")
 
+        # Dismissible changelog toast — appears once per session for returning users
+        if 'dismissed_changelog' not in st.session_state:
+            st.session_state.dismissed_changelog = False
+
+        if not st.session_state.dismissed_changelog:
+            with st.container():
+                st.info("""
+                🆕 **What's new** — thanks for the feedback. We've:
+                - Fixed some measure descriptions that were showing the wrong name
+                - Renamed "Raw Data" to "Score Breakdown" (same thing, clearer name)
+                - Given the Priority Matrix friendlier labels to show where to focus first
+                - Made the help tips match what the numbers in the app actually show
+                """)
+                if st.button("Dismiss", key="dismiss_changelog"):
+                    st.session_state.dismissed_changelog = True
+                    st.rerun()
+
         # Get applicable measures for this dataset type
         applicable_measures = data_processor.get_applicable_measures(dataset_type)
 


### PR DESCRIPTION
## Summary

Adds a session-scoped info box that appears the first time a provider loads, summarising recent app changes in **plain English**. Dismiss button hides it for the rest of the session.

PR #12's original copy used technical phrasing (\"TP07–TP11\", \"correlation display\", \"calculation methodology\"). Rewritten to match the actual audience — housing officers and domain experts, almost none of whom are technical. References the app's own UI terms (Priority Matrix, Score Breakdown) rather than implementation concepts.

## Merge ordering (important)

Toast copy references changes from:
- **Group A** (PR #21 — tooltip alignment) — \"Made the help tips match what the numbers in the app actually show\"
- **Group C** (PR #25 — UI polish) — \"Renamed 'Raw Data' to 'Score Breakdown'\", \"friendlier Priority Matrix labels\"
- **PR #14** (already merged) — \"Fixed some measure descriptions that were showing the wrong name\"

**Merge order requested:** #21 → #25 → #26 (this PR). Otherwise returning users see a toast announcing changes that aren't live yet.

## Scope discipline

- **Session-state only**, not cookies/local-storage: PR #12's design. A \"dismissed once per user forever\" toast would need browser persistence — out of scope.
- **No `unsafe_allow_html`**: content is a plain `st.info()` markdown string, no HTML injection surface.

## Test plan

- [x] `python3 -c \"import ast; ast.parse(open('app.py').read())\"` — parses
- [x] Gitleaks pre-commit passed
- [ ] **Manual verification (please do):**
  - Load a provider → confirm blue \"What's new\" info box appears above the dashboard
  - Click **Dismiss** → confirm box disappears and does not return on subsequent provider loads
  - Reload page (new session) → confirm box reappears
  - Read the copy as if you were a housing officer with no data background — does every line make sense?

Generated with Claude Code