### PR TITLE
docs(handoff): update for 6 draft rescue PRs awaiting review, Group G deferred

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,8 +1,8 @@
-# Session Handoff: Branch Cleanup & Cherry-Picking UI/UX Features
+# Session Handoff: PR #12 Cherry-Pick In Review, Group G Pending
 
 **Date:** April 2026
-**Branch:** `main` (all migration work merged)
-**Status:** Migration complete and live. Cleanup and feature cherry-pick pending.
+**Branch:** `main` (clean; 6 draft feature branches open for review)
+**Status:** 6 of 7 rescue PRs open as drafts, awaiting manual browser verification and merge. Group G (dynamic ETL) deferred.
 
 ---
 
@@ -15,139 +15,131 @@
 - **Cert:** Let's Encrypt (auto-renewed)
 - **Source:** `main` branch (auto-deploys on push)
 
-### Recently Merged PRs
+### Recently Merged PRs (chronological)
 | PR | Title | Status |
 |----|-------|--------|
 | #13 | Migrate from Replit to Railway with Docker containerisation | Merged |
 | #14 | Fix LCRA/LCHO dataset mix-up and TP description drift | Merged |
 | #15 | Add tsm_measures.py to Dockerfile COPY list | Merged |
 | #16 | Harden Docker image (allowlist .dockerignore) + add gitleaks pre-commit | Merged |
-| #17 | docs: Update documentation with custom domain URL | Merged |
+| #17 | Update documentation with custom domain URL | Merged |
 | #18 | Document pre-commit hook setup in README | Merged |
+| #19 | Update HANDOFF for branch cleanup and PR #12 cherry-pick | Merged |
 
-### Open PRs
-| PR | Title | Action Needed |
-|----|-------|---------------|
-| #12 | Fix critical data bugs, improve UI/UX, add Railway deployment config | Cherry-pick unique features (see Task 2) |
+### Open draft PRs — PR #12 cherry-pick rescue
+Review in this order (small → big, dependencies last):
+
+| PR | Title | Size | Merge notes |
+|----|-------|------|-------------|
+| [#21](https://github.com/Teev-dev/HAILIE_Insights_Engine/pull/21) | fix(tooltips): align priority formula/thresholds with code | +6/-6 | Fixes a real accuracy bug — tooltip described thresholds (>60) and formula that no longer matched code (>70). Safe to merge first. |
+| [#22](https://github.com/Teev-dev/HAILIE_Insights_Engine/pull/22) | feat(config): CURRENT_DATA_YEAR constant | +9/-4 | Adds single module-level constant in `app.py` for user-facing year labels. Fixes a bug in PR #12's own diff (missing f-string prefix). |
+| [#23](https://github.com/Teev-dev/HAILIE_Insights_Engine/pull/23) | feat(tools): add validate_etl.py ETL spot-check | +168 | New diagnostic script. Excluded from Docker image (dev/CI tool, not runtime). Uses `config.DB_PATH`. |
+| [#24](https://github.com/Teev-dev/HAILIE_Insights_Engine/pull/24) | feat(obs): env-gated Sentry SDK | +14 | No-op unless `SENTRY_DSN` is set. Added `send_default_pii=False` as hardening beyond PR #12's version. |
+| [#25](https://github.com/Teev-dev/HAILIE_Insights_Engine/pull/25) | feat(ui): polish labels, correlation format, quadrants, Plotly theming | +78/-35 | Biggest change. "Raw Data" → "Score Breakdown"; correlation shown as "Strong (0.72)"; Quick Wins → Maintain & Protect; consistent Plotly theme; momentum dict now carries `latest_year`/`prior_year`. `html.escape()` preserved throughout. |
+| [#26](https://github.com/Teev-dev/HAILIE_Insights_Engine/pull/26) | feat(ui): dismissible changelog toast | +18 | Merge last — toast copy announces changes from #21 and #25. Leads with the open-source/licensing bullet for housing orgs evaluating adoption. |
+
+### Still open
+| PR | Title | Action |
+|----|-------|--------|
+| #12 | Fix critical data bugs, improve UI/UX, add Railway deployment config | Close after #21–#26 (and future Group G) are all merged, with a note linking to the rescue PRs. |
+
+### Deferred
+- **Group G — dynamic Excel header detection in `build_analytics_db_v2.py`** (349-line refactor). Replaces fragile hardcoded column positions with dynamic header detection. Biggest and riskiest remaining cherry-pick. Deferred until #21–#26 merge so it lands against a clean base. See "Task 3" below.
 
 ---
 
-## Task 1: Safe Branch Deletions
+## Task 1: Browser-verify each draft PR ⚠️
 
-Run these commands in the cleanup session:
+All 6 draft PRs are code-reviewed, DCO-signed, and pre-commit-checked, but **none have been run in a browser**. Each has its own worktree already set up, so reviewing is just `cd` and `streamlit run`:
 
 ```bash
-# Remote branch deletions (all merged, nothing lost)
-git push origin --delete migration/railway
-git push origin --delete docs/custom-domain-url
-git push origin --delete Feature_2025_data
+# One-time per session — make sure deps are installed in the shared venv:
+source /Users/teev/Software_Projects/hailie-tsm-insights/.venv/bin/activate
+pip install -e /Users/teev/Software_Projects/hailie-tsm-insights
 
-# Replit-agent branch - review first (Replit auto-publishes, likely stale)
-# Check: git log origin/replit-agent --not origin/main --oneline
-# If all commits are Replit auto-publishes (no unique user work), delete:
-git push origin --delete replit-agent
+# Then for each PR, cd into its worktree and run:
+cd /Users/teev/Software_Projects/hailie-worktrees/group-a-tooltips       # PR #21
+streamlit run app.py
+# Browser opens http://localhost:8501 — verify per checklist below, then Ctrl-C.
 
-# Local branch cleanup
-git branch -D migration/railway
-git branch -D fix/data-accuracy-lcra-lcho
-git branch -D docs/custom-domain-url
-git branch -D security/review-fixes
-
-# Drop stale stash (only adds `import html` — already in main)
-git stash drop stash@{0}
+cd /Users/teev/Software_Projects/hailie-worktrees/group-b-data-year      # PR #22
+streamlit run app.py
+# ...etc for group-f-validate-etl, group-e-sentry, group-c-ui-polish, group-d-changelog
 ```
 
-**Keep these branches:**
-- `main` (obviously)
-- `feature/ui-ux-improvements` (has open PR #12 with unique features — see Task 2)
+### Per-PR verification checklist
+
+- **#21:** Select any provider → open "How Priority Works" expander → confirm thresholds show `>70 / 50-70 / 30-50 / <30` and formula shows `(Improvement Potential × 0.6) + (Correlation Strength × 100 × 0.4)`. Open momentum expander → confirm note reflects 2024→2025 comparison.
+- **#22:** Confirm sidebar "Enhanced Analytics Engine" info block shows `Data source: 2025 TSM Dataset` (NOT the literal string `{CURRENT_DATA_YEAR}`). Footer shows `Data: 2025 TSM`.
+- **#23:** `python3 validate_etl.py` against a built `data/hailie_analytics_v2.duckdb` — all 6 checks should pass, exit 0. Also `docker build -t hailie-insights . && docker run --rm hailie-insights find /app -name validate_etl.py` should return nothing (script must stay out of image).
+- **#24:** Start with `SENTRY_DSN` unset → no Sentry output in console. Set `SENTRY_DSN=<test dsn>` and raise a test exception → event should reach Sentry.
+- **#25:** Priority card shows `"Strong (0.72)"` format; Priority Matrix quadrants show `Maintain & Protect` / `Lower Impact`; matrix y-axis reads `Relationship with Overall Satisfaction`; sidebar expander reads `📋 Score Breakdown`.
+- **#26:** Load a provider → blue "What's new" info box appears. Dismiss → disappears for session. Read aloud as if you were a housing officer — does every line make sense?
 
 ---
 
-## Task 2: Cherry-Pick UI/UX Features from PR #12
+## Task 2: Merge order
 
-PR #12 (`feature/ui-ux-improvements` branch, commit `788a079`) contains unique features NOT in main. **The user wants ALL of these — they are positive improvements.**
+After each PR passes browser verification:
 
-### Features to Cherry-Pick
+```
+#21 → #22 → #23 → #24 → #25 → #26
+```
 
-1. **Sentry SDK integration**
-   - New dependency: `sentry-sdk`
-   - Env var gated: `SENTRY_DSN`
-   - Add observability for production errors
+Rationale:
+- #21 and #22 are tiny and independent — land first.
+- #23 and #24 are pure additions, no dashboard impact.
+- #25 is the biggest UI change — review carefully.
+- #26 (toast) references #21 and #25 content, so it must merge last or the toast announces changes that aren't live.
 
-2. **Dismissible "Recent Updates" changelog toast**
-   - Shows on first load for returning users
-   - Dismisses on click
-   - Tracks which version/date the user has seen
+After each merge, clean up the worktree:
+```bash
+git worktree remove /Users/teev/Software_Projects/hailie-worktrees/<slug>
+```
+Worktree slugs: `group-a-tooltips`, `group-b-data-year`, `group-c-ui-polish`, `group-d-changelog`, `group-e-sentry`, `group-f-validate-etl`.
 
-3. **Rename "Raw Data" section → "Score Breakdown"**
-   - User-facing UI label change
-   - More descriptive, less confusing
+---
 
-4. **Priority formula/threshold fixes**
-   - Tooltip-to-code mismatch corrections
-   - Ensures tooltips accurately describe the actual calculation logic
-   - File: `tooltip_definitions.py` + any priority calc code
+## Task 3: Group G — Dynamic ETL Header Detection (deferred)
 
-5. **Correlation display format**
-   - Before: "72.0%"
-   - After: "Strong (0.72)"
-   - Qualitative label + coefficient, matches statistics conventions
+**Scope:** Port PR #12's `build_analytics_db_v2.py` refactor (+349/-0 lines) that replaces hardcoded Excel column positions with dynamic header detection. Matters because the Regulator of Social Housing sometimes shifts columns between annual releases — the current hardcoded-position parser is fragile.
 
-6. **Priority matrix quadrant labels**
-   - Fixed labels: "High Priority", "Maintain & Protect", "Lower Impact", "Low Priority"
-   - Previously had misleading quadrant names like "Quick Wins"
+**Why deferred:** Biggest and riskiest remaining change. The ETL produces the DuckDB that drives the entire app; a subtle porting error would silently corrupt analytics.
 
-7. **Dynamic year references**
-   - New constant: `CURRENT_DATA_YEAR`
-   - Replaces hardcoded "2025" references in user-facing text
-   - Simplifies annual updates
+**Approach when ready:**
+1. Fresh worktree off latest `main` (post #21–#26 merges):
+   ```bash
+   git worktree add /Users/teev/Software_Projects/hailie-worktrees/group-g-dynamic-etl -b feat/etl-dynamic-headers origin/main
+   ```
+2. Port `build_analytics_db_v2.py` from `origin/feature/ui-ux-improvements` (the PR #12 branch), preserving main's current path/import conventions (`config.py`, `tsm_measures.py`).
+3. **End-to-end ETL run required before marking ready:**
+   ```bash
+   python3 build_analytics_db_v2.py
+   python3 validate_etl.py    # all 6 checks must pass
+   ```
+4. **Diff the new DuckDB against the current production one** to confirm no regressions in provider scores, percentiles, correlations. Spot-check at least 5 providers (including 1 LCHO, 1 COMBINED) against the source Excel files by hand.
+5. Draft PR only after steps 3 and 4 pass.
 
-8. **Consistent Plotly chart theming**
-   - Standardised chart styling across all visualisations
-   - Matches app brand colours (#2E5BBA primary)
+---
 
-9. **Remove unused confidence interval checkbox**
-   - Dead UI element that did nothing
-   - Cleanup for clarity
+## Task 4: Pre-existing issues found during cherry-pick (follow-ups)
 
-10. **`validate_etl.py` — data integrity check script**
-    - New diagnostic tool (alongside existing `diagnose_duplicates.py`, `db_view_script.py`, `review_pvalues.py`)
-    - Validates ETL output before deployment
+Not introduced by any rescue PR — noticed during the port but out of scope to fix:
 
-### Cherry-Pick Strategy (Recommended)
+1. **`dashboard.py:859` KeyError risk** — `f"1. **Focus on {priority['measure_name']}** - ..."` directly subscripts `measure_name`, but `identify_priority` in `analytics_refactored.py:310+` returns `priority_description` (no `measure_name` key). Would throw if it ever fires.
+2. **`analytics_refactored.py:265` nonexistent method** — `self.data_processor.get_percentile_for_score(tp_measure, score)` is called in a fallback branch. Method doesn't exist in `data_processor_enhanced.py`. Only fires if a provider has scores for a measure with no pre-calculated percentile, but would `AttributeError` when it does.
+3. **5 hardcoded "2025 vs 2024" momentum labels in `dashboard.py`** use the `.get('latest_year', 2025)` fallback introduced by #25. Infrastructure is in place; wiring to actual data years is a follow-up.
 
-**Option A: One PR per logical group** (recommended for review-ability)
-- PR: "Add Sentry observability"
-- PR: "UI polish: labels, correlations, quadrants, themes"
-- PR: "Add CURRENT_DATA_YEAR constant for dynamic year refs"
-- PR: "Add validate_etl.py diagnostic tool"
-- PR: "Add dismissible changelog toast"
+Recommend filing each as a GitHub issue labelled `bug` or `good-first-issue` so they don't get lost.
 
-### Execution Plan
+---
 
-1. **Read PR #12 diff:** `gh pr diff 12` to see full changes
-2. **Check each feature against current main** — some may have been partially ported already via PR #14
-3. **Create feature branches off main** for each logical group
-4. **Apply changes manually** (don't cherry-pick the commit directly — too much conflict potential since main has moved significantly)
-5. **Test locally** in Docker before pushing
-6. **Open draft PRs** per CLAUDE.md protocol
-7. **Close PR #12** with note that features were rescued via new PRs
+## Task 5: Close PR #12
 
-### Files Likely to Need Edits
-
-- `app.py` — changelog toast, `CURRENT_DATA_YEAR` constant
-- `dashboard.py` — "Raw Data" → "Score Breakdown", correlation display, quadrant labels
-- `tooltip_definitions.py` — priority formula/threshold fixes
-- `styles.py` — Plotly theme consistency
-- `pyproject.toml` — `sentry-sdk` dependency
-- New file: `validate_etl.py`
-
-### Caution Points
-
-- **Don't just merge PR #12** — it contains old Dockerfile/railway.toml versions that conflict with the migration work
-- **Check correlation display code** — current main may already have some of these fixes (from PR #14)
-- **Test Sentry integration** with a real DSN before marking PR ready
-- **Follow CLAUDE.md guardrails** — draft PRs only, TDD preferred, html.escape() on dynamic UI content
+After #21–#26 and Group G all merge:
+1. Comment on PR #12 linking each rescue PR.
+2. Close without merging (its Dockerfile/railway.toml versions are stale and would regress the migration).
+3. `git push origin --delete feature/ui-ux-improvements`.
 
 ---
 
@@ -159,6 +151,7 @@ PR #12 (`feature/ui-ux-improvements` branch, commit `788a079`) contains unique f
 - `ADRs/ADR-004-migration-replit-to-railway.md` — migration decision record
 - `MAINTENANCE.md` — annual update procedures
 - `DEPLOYMENT.md` — Railway deployment runbook
+- `guides/collaboration-protocol.md` §5 — AI autonomous session protocol (worktree isolation, draft PRs, DCO)
 
 ### Critical Guardrails (from CLAUDE.md)
 - All data access through `data_processor_enhanced.py`
@@ -168,8 +161,8 @@ PR #12 (`feature/ui-ux-improvements` branch, commit `788a079`) contains unique f
 - LCRA vs LCHO peer isolation is non-negotiable
 - No PII logging (use provider codes, not names)
 
-### Year Default (Important for Future)
-Currently `year=2025` in 10+ places. Next update: November 2026 when new TSM data publishes. Full checklist in `MAINTENANCE.md`.
+### Year Default
+`year=2025` is still the default in 10+ query-layer places. #22 added `CURRENT_DATA_YEAR` only for user-facing text. Query-layer defaults remain maintained via `MAINTENANCE.md` for the annual update (next: November 2026 when new TSM data publishes).
 
 ---
 
@@ -179,7 +172,8 @@ Currently `year=2025` in 10+ places. Next update: November 2026 when new TSM dat
 cd /Users/teev/Software_Projects/hailie-tsm-insights
 git checkout main
 git pull origin main
+gh pr list --state open
 ```
 
 Tell Claude Code:
-"Read HANDOFF.md for context. Start with Task 1 (safe branch deletions), then proceed with Task 2 (cherry-pick UI/UX features from PR #12). The user wants ALL features from PR #12 — they are positive improvements."
+*"Read HANDOFF.md. Pick up from wherever we are: if #21–#26 still open, help with browser verification and review feedback. If merged, start Group G per Task 3."*


### PR DESCRIPTION
## Summary

Rewrites `HANDOFF.md` to reflect current state: branch cleanup done, 6 cherry-pick PRs (#21–#26) open as drafts, Group G (dynamic ETL) explicitly deferred.

The previous HANDOFF still described Task 1 (branch cleanup) as pending and Task 2 (cherry-picks) as unstarted. A new reviewer landing on `main` would have been mis-led about where we are.

## What changed

- Current State → new \"Open draft PRs\" table covering #21–#26 with one-line merge notes each
- New **Task 1**: per-PR browser-verification checklist (the critical missing piece — none have been run in a browser yet)
- New **Task 2**: suggested merge order with rationale
- **Task 3**: Group G approach with the mandatory ETL-run + validate_etl + manual spot-check gates before it can be marked ready
- New **Task 4**: three pre-existing bugs found during the port, flagged for follow-up issues
- **Task 5**: PR #12 close-out

## Not a code change

Pure docs. No runtime impact. Merging this keeps HANDOFF as the single source of truth for session handoffs.

## Test plan

- [x] Markdown renders cleanly on GitHub (previewed in editor)
- [x] All linked PR numbers resolve
- [x] Gitleaks pre-commit passed

Generated with Claude Code