### PR TITLE
fix(build): configure setuptools py-modules for flat Python layout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,3 +29,22 @@ dependencies = [
 Homepage = "https://github.com/Teev-dev/HAILIE_Insights_Engine"
 Repository = "https://github.com/Teev-dev/HAILIE_Insights_Engine"
 Issues = "https://github.com/Teev-dev/HAILIE_Insights_Engine/issues"
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+# Flat-layout: top-level .py files are the package, ADRs/data/pages/guides are not.
+# Without this, setuptools auto-discovery fails on the non-package top-level dirs.
+[tool.setuptools]
+py-modules = [
+    "app",
+    "dashboard",
+    "analytics_refactored",
+    "data_processor_enhanced",
+    "config",
+    "styles",
+    "tooltip_definitions",
+    "mobile_utils",
+    "tsm_measures",
+]


### PR DESCRIPTION
## Summary

Fixes a cold failure on `pip install -e .` and `uv sync`. Surfaced while setting up a local browser-review environment for the PR #21–#26 cherry-picks.

**Before:**
```
error: Multiple top-level packages discovered in a flat-layout:
['ADRs', 'data', 'pages', 'guides'].
```

**After:** editable install's package-discovery step completes without error.

## What changed

- New `[tool.setuptools]` section with explicit `py-modules` list covering the nine runtime top-level modules (`app`, `dashboard`, `analytics_refactored`, `data_processor_enhanced`, `config`, `styles`, `tooltip_definitions`, `mobile_utils`, `tsm_measures`).
- New `[build-system]` table pinning `setuptools>=68`, which is when the `py-modules` semantics stabilised.

## What's deliberately out

ETL/diagnostic scripts (`build_analytics_db.py`, `build_analytics_db_v2.py`, `diagnose_duplicates.py`, `db_view_script.py`, `review_pvalues.py`, and `validate_etl.py` if PR #23 merges first) are **not** listed. Same treatment as `.dockerignore` — they're dev tools, not part of the installable runtime package.

## Production impact

Zero. Railway runs `python:3.11-slim` via Dockerfile and doesn't go through the setuptools install path at all. This only unblocks local dev and CI tooling that invokes `pip install -e .`.

## Test plan

- [x] `pip install -e .` from a fresh worktree: \"Preparing editable metadata: done\" — the original flat-layout error is gone
- [x] Gitleaks pre-commit passed
- [ ] Reviewer: from a clean Python 3.11 venv, confirm `pip install -e .` succeeds end-to-end (the system I'm on has only Python 3.9, which hits a *separate* `requires-python >=3.11` check — unrelated to this fix, but worth noting for the next reviewer)

## Context

Surfaced during the PR #12 cherry-pick session. Not on the original rescue plan — found while trying to install deps for browser-review.

Generated with Claude Code