### PR TITLE
docs(handoff): post-rescue state, Group G + 3 follow-up issues

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,8 +1,8 @@
-# Session Handoff: PR #12 Cherry-Pick In Review, Group G Pending
+# Session Handoff: PR #12 Rescue Done, Group G + Follow-ups Pending
 
 **Date:** April 2026
-**Branch:** `main` (clean; 6 draft feature branches open for review)
-**Status:** 6 of 7 rescue PRs open as drafts, awaiting manual browser verification and merge. Group G (dynamic ETL) deferred.
+**Branch:** `main` (clean; only remaining PR #12 work is Group G)
+**Status:** PR #12 rescue complete — 6/7 cherry-pick PRs merged, PR #12 closed. Group G (dynamic ETL) deferred. Three pre-existing bugs filed as follow-up issues.
 
 ---
 
@@ -15,131 +15,58 @@
 - **Cert:** Let's Encrypt (auto-renewed)
 - **Source:** `main` branch (auto-deploys on push)
 
-### Recently Merged PRs (chronological)
-| PR | Title | Status |
-|----|-------|--------|
-| #13 | Migrate from Replit to Railway with Docker containerisation | Merged |
-| #14 | Fix LCRA/LCHO dataset mix-up and TP description drift | Merged |
-| #15 | Add tsm_measures.py to Dockerfile COPY list | Merged |
-| #16 | Harden Docker image (allowlist .dockerignore) + add gitleaks pre-commit | Merged |
-| #17 | Update documentation with custom domain URL | Merged |
-| #18 | Document pre-commit hook setup in README | Merged |
-| #19 | Update HANDOFF for branch cleanup and PR #12 cherry-pick | Merged |
+### Recently Merged PRs (PR #12 rescue + supporting changes)
+| PR | Title | Notes |
+|----|-------|-------|
+| #21 | fix(tooltips): align priority formula/thresholds with code | Group A |
+| #22 | feat(config): CURRENT_DATA_YEAR constant | Group B; lives in `app.py` |
+| #23 | feat(tools): add validate_etl.py ETL spot-check | Group F; excluded from Docker image |
+| #24 | feat(obs): env-gated Sentry SDK | Group E; `send_default_pii=False`; no `[streamlit]` extra (doesn't exist in sentry-sdk 2.x) |
+| #25 | feat(ui): polish labels, correlation format, quadrants, Plotly theming | Group C |
+| #26 | feat(ui): dismissible 'What's new' changelog toast | Group D; copy in plain English for housing domain users |
+| #27 | docs(handoff): mid-rescue state | superseded by this update |
+| #28 | fix(build): configure setuptools py-modules | unblocks `pip install -e .` |
 
-### Open draft PRs — PR #12 cherry-pick rescue
-Review in this order (small → big, dependencies last):
+### Closed without merging
+- **#12** (`feature/ui-ux-improvements`) — original PR. Its Dockerfile/railway.toml/data-path versions would have regressed the migration. Unique features rescued via PRs #21–#26. Branch deleted.
 
-| PR | Title | Size | Merge notes |
-|----|-------|------|-------------|
-| [#21](https://github.com/Teev-dev/HAILIE_Insights_Engine/pull/21) | fix(tooltips): align priority formula/thresholds with code | +6/-6 | Fixes a real accuracy bug — tooltip described thresholds (>60) and formula that no longer matched code (>70). Safe to merge first. |
-| [#22](https://github.com/Teev-dev/HAILIE_Insights_Engine/pull/22) | feat(config): CURRENT_DATA_YEAR constant | +9/-4 | Adds single module-level constant in `app.py` for user-facing year labels. Fixes a bug in PR #12's own diff (missing f-string prefix). |
-| [#23](https://github.com/Teev-dev/HAILIE_Insights_Engine/pull/23) | feat(tools): add validate_etl.py ETL spot-check | +168 | New diagnostic script. Excluded from Docker image (dev/CI tool, not runtime). Uses `config.DB_PATH`. |
-| [#24](https://github.com/Teev-dev/HAILIE_Insights_Engine/pull/24) | feat(obs): env-gated Sentry SDK | +14 | No-op unless `SENTRY_DSN` is set. Added `send_default_pii=False` as hardening beyond PR #12's version. |
-| [#25](https://github.com/Teev-dev/HAILIE_Insights_Engine/pull/25) | feat(ui): polish labels, correlation format, quadrants, Plotly theming | +78/-35 | Biggest change. "Raw Data" → "Score Breakdown"; correlation shown as "Strong (0.72)"; Quick Wins → Maintain & Protect; consistent Plotly theme; momentum dict now carries `latest_year`/`prior_year`. `html.escape()` preserved throughout. |
-| [#26](https://github.com/Teev-dev/HAILIE_Insights_Engine/pull/26) | feat(ui): dismissible changelog toast | +18 | Merge last — toast copy announces changes from #21 and #25. Leads with the open-source/licensing bullet for housing orgs evaluating adoption. |
-
-### Still open
-| PR | Title | Action |
-|----|-------|--------|
-| #12 | Fix critical data bugs, improve UI/UX, add Railway deployment config | Close after #21–#26 (and future Group G) are all merged, with a note linking to the rescue PRs. |
-
-### Deferred
-- **Group G — dynamic Excel header detection in `build_analytics_db_v2.py`** (349-line refactor). Replaces fragile hardcoded column positions with dynamic header detection. Biggest and riskiest remaining cherry-pick. Deferred until #21–#26 merge so it lands against a clean base. See "Task 3" below.
+### Branch state
+Only `main` exists locally and on origin. All rescue branches and worktrees have been cleaned up.
 
 ---
 
-## Task 1: Browser-verify each draft PR ⚠️
+## Task 1: Group G — Dynamic ETL Header Detection
 
-All 6 draft PRs are code-reviewed, DCO-signed, and pre-commit-checked, but **none have been run in a browser**. Each has its own worktree already set up, so reviewing is just `cd` and `streamlit run`:
+**Scope:** Port PR #12's `build_analytics_db_v2.py` refactor (+349 lines) that replaces hardcoded Excel column positions with dynamic header detection. Matters because the Regulator of Social Housing sometimes shifts columns between annual releases — the current hardcoded-position parser is fragile and likely to break on the November 2026 data release.
 
-```bash
-# One-time per session — make sure deps are installed in the shared venv:
-source /Users/teev/Software_Projects/hailie-tsm-insights/.venv/bin/activate
-pip install -e /Users/teev/Software_Projects/hailie-tsm-insights
-
-# Then for each PR, cd into its worktree and run:
-cd /Users/teev/Software_Projects/hailie-worktrees/group-a-tooltips       # PR #21
-streamlit run app.py
-# Browser opens http://localhost:8501 — verify per checklist below, then Ctrl-C.
-
-cd /Users/teev/Software_Projects/hailie-worktrees/group-b-data-year      # PR #22
-streamlit run app.py
-# ...etc for group-f-validate-etl, group-e-sentry, group-c-ui-polish, group-d-changelog
-```
-
-### Per-PR verification checklist
-
-- **#21:** Select any provider → open "How Priority Works" expander → confirm thresholds show `>70 / 50-70 / 30-50 / <30` and formula shows `(Improvement Potential × 0.6) + (Correlation Strength × 100 × 0.4)`. Open momentum expander → confirm note reflects 2024→2025 comparison.
-- **#22:** Confirm sidebar "Enhanced Analytics Engine" info block shows `Data source: 2025 TSM Dataset` (NOT the literal string `{CURRENT_DATA_YEAR}`). Footer shows `Data: 2025 TSM`.
-- **#23:** `python3 validate_etl.py` against a built `data/hailie_analytics_v2.duckdb` — all 6 checks should pass, exit 0. Also `docker build -t hailie-insights . && docker run --rm hailie-insights find /app -name validate_etl.py` should return nothing (script must stay out of image).
-- **#24:** Start with `SENTRY_DSN` unset → no Sentry output in console. Set `SENTRY_DSN=<test dsn>` and raise a test exception → event should reach Sentry.
-- **#25:** Priority card shows `"Strong (0.72)"` format; Priority Matrix quadrants show `Maintain & Protect` / `Lower Impact`; matrix y-axis reads `Relationship with Overall Satisfaction`; sidebar expander reads `📋 Score Breakdown`.
-- **#26:** Load a provider → blue "What's new" info box appears. Dismiss → disappears for session. Read aloud as if you were a housing officer — does every line make sense?
-
----
-
-## Task 2: Merge order
-
-After each PR passes browser verification:
-
-```
-#21 → #22 → #23 → #24 → #25 → #26
-```
-
-Rationale:
-- #21 and #22 are tiny and independent — land first.
-- #23 and #24 are pure additions, no dashboard impact.
-- #25 is the biggest UI change — review carefully.
-- #26 (toast) references #21 and #25 content, so it must merge last or the toast announces changes that aren't live.
-
-After each merge, clean up the worktree:
-```bash
-git worktree remove /Users/teev/Software_Projects/hailie-worktrees/<slug>
-```
-Worktree slugs: `group-a-tooltips`, `group-b-data-year`, `group-c-ui-polish`, `group-d-changelog`, `group-e-sentry`, `group-f-validate-etl`.
-
----
-
-## Task 3: Group G — Dynamic ETL Header Detection (deferred)
-
-**Scope:** Port PR #12's `build_analytics_db_v2.py` refactor (+349/-0 lines) that replaces hardcoded Excel column positions with dynamic header detection. Matters because the Regulator of Social Housing sometimes shifts columns between annual releases — the current hardcoded-position parser is fragile.
-
-**Why deferred:** Biggest and riskiest remaining change. The ETL produces the DuckDB that drives the entire app; a subtle porting error would silently corrupt analytics.
+**Why deferred:** Biggest and riskiest remaining change. The ETL produces the DuckDB that drives the entire app; a subtle porting error would silently corrupt analytics across all providers.
 
 **Approach when ready:**
-1. Fresh worktree off latest `main` (post #21–#26 merges):
+
+1. Fresh worktree off latest `main`:
    ```bash
    git worktree add /Users/teev/Software_Projects/hailie-worktrees/group-g-dynamic-etl -b feat/etl-dynamic-headers origin/main
    ```
-2. Port `build_analytics_db_v2.py` from `origin/feature/ui-ux-improvements` (the PR #12 branch), preserving main's current path/import conventions (`config.py`, `tsm_measures.py`).
+2. Port `build_analytics_db_v2.py` from the now-closed `feature/ui-ux-improvements` branch (git has it even though the branch is deleted — see `git log --all`). Preserve main's current path/import conventions (`config.py`, `tsm_measures.py`).
 3. **End-to-end ETL run required before marking ready:**
    ```bash
    python3 build_analytics_db_v2.py
    python3 validate_etl.py    # all 6 checks must pass
    ```
 4. **Diff the new DuckDB against the current production one** to confirm no regressions in provider scores, percentiles, correlations. Spot-check at least 5 providers (including 1 LCHO, 1 COMBINED) against the source Excel files by hand.
-5. Draft PR only after steps 3 and 4 pass.
+5. Open draft PR only after steps 3 and 4 pass.
 
 ---
 
-## Task 4: Pre-existing issues found during cherry-pick (follow-ups)
+## Task 2: Follow-up issues (filed 2026-04-17)
 
-Not introduced by any rescue PR — noticed during the port but out of scope to fix:
+Three pre-existing bugs found during the rescue — none introduced by rescue PRs, all in main pre-rescue:
 
-1. **`dashboard.py:859` KeyError risk** — `f"1. **Focus on {priority['measure_name']}** - ..."` directly subscripts `measure_name`, but `identify_priority` in `analytics_refactored.py:310+` returns `priority_description` (no `measure_name` key). Would throw if it ever fires.
-2. **`analytics_refactored.py:265` nonexistent method** — `self.data_processor.get_percentile_for_score(tp_measure, score)` is called in a fallback branch. Method doesn't exist in `data_processor_enhanced.py`. Only fires if a provider has scores for a measure with no pre-calculated percentile, but would `AttributeError` when it does.
-3. **5 hardcoded "2025 vs 2024" momentum labels in `dashboard.py`** use the `.get('latest_year', 2025)` fallback introduced by #25. Infrastructure is in place; wiring to actual data years is a follow-up.
+- **[#29](https://github.com/Teev-dev/HAILIE_Insights_Engine/issues/29)** `bug` `good first issue` — `dashboard.py:859` subscripts `priority['measure_name']` but `identify_priority` returns `priority_description`. Latent `KeyError`. One-line fix.
+- **[#30](https://github.com/Teev-dev/HAILIE_Insights_Engine/issues/30)** `bug` — `analytics_refactored.py:265` calls `data_processor.get_percentile_for_score(...)`, which doesn't exist. Fallback branch; recommend removing in favour of an ETL-integrity check (validate_etl.py check 5 already enforces this).
+- **[#31](https://github.com/Teev-dev/HAILIE_Insights_Engine/issues/31)** `enhancement` `good first issue` — `dashboard.py` momentum labels are still effectively hardcoded `2025 vs 2024`. Infrastructure from PR #25 is in place; need `data_processor.get_provider_years` + `CURRENT_DATA_YEAR` moved to `config.py`.
 
-Recommend filing each as a GitHub issue labelled `bug` or `good-first-issue` so they don't get lost.
-
----
-
-## Task 5: Close PR #12
-
-After #21–#26 and Group G all merge:
-1. Comment on PR #12 linking each rescue PR.
-2. Close without merging (its Dockerfile/railway.toml versions are stale and would regress the migration).
-3. `git push origin --delete feature/ui-ux-improvements`.
+Priority: **#29 first** (simple one-liner, prevents a real crash if hit). Then #30 (correctness). Then #31 (enhancement; ship before November 2026 TSM data release so annual update is lower-touch).
 
 ---
 
@@ -158,11 +85,17 @@ After #21–#26 and Group G all merge:
 - Analytics in `analytics_refactored.py`, rendering in `dashboard.py`
 - Data paths via `config.py` only (no hardcoding)
 - `html.escape()` required on all dynamic content in `unsafe_allow_html`
-- LCRA vs LCHO peer isolation is non-negotiable
+- LCRA vs LCHO peer isolation is non-negotiable — always pass `dataset_type` explicitly
 - No PII logging (use provider codes, not names)
 
 ### Year Default
-`year=2025` is still the default in 10+ query-layer places. #22 added `CURRENT_DATA_YEAR` only for user-facing text. Query-layer defaults remain maintained via `MAINTENANCE.md` for the annual update (next: November 2026 when new TSM data publishes).
+`year=2025` is still the default in ~10 query-layer places (see MAINTENANCE.md). PR #22 added `CURRENT_DATA_YEAR` only for user-facing text. Query-layer defaults remain maintained manually. Next annual update: November 2026.
+
+### Local dev environment
+- Python 3.11 required. `.venv` must be created with `python3.11 -m venv .venv`.
+- Core deps: `pip install duckdb streamlit pandas plotly scipy numpy openpyxl 'sentry-sdk>=2.0.0' pre-commit`
+- Since PR #28, `pip install -e .` also works.
+- Pre-commit hooks require `pre-commit install` once per clone.
 
 ---
 
@@ -172,8 +105,10 @@ After #21–#26 and Group G all merge:
 cd /Users/teev/Software_Projects/hailie-tsm-insights
 git checkout main
 git pull origin main
-gh pr list --state open
+gh issue list --label bug
 ```
 
 Tell Claude Code:
-*"Read HANDOFF.md. Pick up from wherever we are: if #21–#26 still open, help with browser verification and review feedback. If merged, start Group G per Task 3."*
+*"Read HANDOFF.md. Pick up either Group G (dynamic ETL, Task 1) or one of the follow-up issues (#29, #30, #31 in Task 2) — whichever I indicate."*
+
+Recommend starting with **#29** if you want a quick win — it's a 5-minute fix that resolves a real crash risk. Group G is a half-day at minimum with careful verification.


### PR DESCRIPTION
## Summary

Refreshes \`HANDOFF.md\` to reflect the post-rescue state. Previous HANDOFF (from PR #27) was written mid-rescue when the cherry-pick PRs were still open as drafts. Now that all six are merged, #12 is closed, and the three pre-existing bugs have been filed as issues, the handoff needs to point the next session at what's actually left.

## What changed

- **Current State** section updated: all rescue PRs marked merged, #12 marked closed, branch state noted clean.
- **Old Task 1 (browser-verify each draft PR)** — removed; work is done.
- **Old Task 2 (merge order)** — removed; work is done.
- **Old Task 5 (close PR #12)** — removed; done.
- **New Task 1**: Group G approach carried forward (still deferred, unchanged content).
- **New Task 2**: Three follow-up issues filed today — **#29** (`measure_name` KeyError, one-line fix, good first issue), **#30** (nonexistent `get_percentile_for_score` method), **#31** (dynamic momentum years, infrastructure in place, good first issue). Recommended priority order.
- **Local dev environment** section added — surfaced during the rescue that the venv setup (Python 3.11, pre-commit install, core deps) wasn't documented anywhere central.

## Not a code change

Pure docs. No runtime impact.

## Test plan

- [x] Markdown renders on GitHub
- [x] All PR/issue links resolve (#12 closed, #21–#28 merged, #29–#31 open)
- [x] Gitleaks pre-commit passed

Generated with Claude Code