### PR TITLE
fix(analytics): remove dead fallback to nonexistent get_percentile_for_score (#30)

### DIFF
--- a/analytics_refactored.py
+++ b/analytics_refactored.py
@@ -263,14 +263,15 @@ class TSMAnalytics:
             for tp_measure in self.tp_codes[1:]:  # Skip TP01
                 if tp_measure not in provider_scores:
                     continue
-                    
-                # Get percentile (or calculate if not available)
-                if tp_measure in percentile_dict:
-                    percentile = percentile_dict[tp_measure]
-                else:
-                    # Fallback: calculate percentile on the fly
-                    score = provider_scores[tp_measure]
-                    percentile = self.data_processor.get_percentile_for_score(tp_measure, score)
+
+                if tp_measure not in percentile_dict:
+                    # Percentile coverage is enforced by validate_etl.py check 5.
+                    # Reaching this branch means ETL drift — skip rather than invoke
+                    # a nonexistent get_percentile_for_score method.
+                    print(f"Skipping {tp_measure} for provider {provider_code}: no pre-calculated percentile")
+                    continue
+
+                percentile = percentile_dict[tp_measure]
                 
                 # Improvement potential (lower percentile = more room for improvement)
                 improvement_potential = 100 - percentile


### PR DESCRIPTION
## Summary
- `identify_priority` in `analytics_refactored.py` had a fallback branch that called `data_processor.get_percentile_for_score(tp_measure, score)`. No such method exists on `EnhancedTSMDataProcessor` — any invocation would raise `AttributeError`.
- The branch only triggers when `tp_measure not in percentile_dict`, i.e. the ETL produced a score without a matching percentile row. That condition is already enforced by `validate_etl.py` check 5 (\"All scores have corresponding percentiles\").
- Replaces the broken fallback with a `print` + `continue`: a drifted ETL surfaces in Railway logs, priority calculation skips the orphaned measure instead of crashing.
- No `logging` module used — matches existing codebase convention of bare `print()` for runtime warnings (see `data_processor_enhanced.py:42,61`).

Closes #30.

## Test plan
- [x] `python3 -c "import ast; ast.parse(open('analytics_refactored.py').read())"` — syntax check passes
- [x] `pre-commit` gitleaks hook passes on commit
- [ ] Browser smoke: healthy-ETL path (the only path exercisable without synthetic data) — confirm priority card renders a measure for an LCRA and LCHO provider. The missing-percentile path can't be exercised against prod data without breaking validate_etl.py check 5 first.

## Note
PR #12's version of this code \"fixed\" the call by adding a `dataset_type` argument; the method still didn't exist. This PR takes the HANDOFF-recommended route of removing the dead branch.

Generated with Claude Code