### PR TITLE
docs(roadmap): add dynamic momentum year labels (#31)

### DIFF
--- a/FEATURES_ROADMAP.md
+++ b/FEATURES_ROADMAP.md
@@ -11,6 +11,7 @@ This document tracks potential future enhancements for the HAILIE Insights Engin
 - **Historical Comparison**: Compare any two years side-by-side
 - **Momentum Deep Dive**: Detailed breakdown of which specific interventions drove changes
 - **Rolling Averages**: Smooth out year-to-year volatility with 2-year or 3-year averages
+- **Dynamic momentum year labels** ([#31](https://github.com/Teev-dev/HAILIE_Insights_Engine/issues/31)): `calculate_momentum` currently hardcodes `latest_year: 2025` / `prior_year: 2024` in every return branch, so the UI would still say "2025 vs 2024" after the Nov 2026 dataset lands. Fix needs `get_provider_years` on the data processor, `CURRENT_DATA_YEAR` moved to `config.py`, and the four return branches rewritten to derive years from the data. Would let the annual update procedure drop the `latest_year`/`prior_year` bullets from MAINTENANCE.md.
 
 ## Advanced Analytics
 **Status**: Potential additions
@@ -77,5 +78,5 @@ This roadmap is a living document. When starting a new development session:
 
 ---
 
-*Last updated: November 2025*
-*Version: 1.0*
+*Last updated: April 2026*
+*Version: 1.1*


### PR DESCRIPTION
## Summary
- Adds a bullet under **Multi-Year Analytics → Potential Enhancements** in `FEATURES_ROADMAP.md` covering the work tracked by issue #31.
- Implementation sketch captured inline (needs `get_provider_years`, `CURRENT_DATA_YEAR` → `config.py`, rewrite of the four `calculate_momentum` return branches) so a future session doesn't have to re-derive it.
- Bumps the roadmap's version to 1.1 / April 2026.

## Context
- Today's live behaviour ("2025 vs 2024") renders correctly against the current 2024 + 2025 dataset; the dynamic-year enhancement becomes visible once the Nov 2026 TSM data lands.
- Docs only — no code change ships with this PR.

## Open question
Issue #31 can either stay open (easier to track and label) or be closed with a comment pointing to the roadmap entry. Happy to go either way.

## Test plan
- [x] `pre-commit` hook passes
- [ ] Eyeball the diff / preview markdown if wanted

Generated with Claude Code