### PR TITLE
feat(ui): strip decorative emojis from user-facing copy (#37)

### DIFF
--- a/analytics_refactored.py
+++ b/analytics_refactored.py
@@ -126,7 +126,7 @@ class TSMAnalytics:
                 return {
                     'direction': "insufficient_data",
                     'momentum_text': "Insufficient multi-year data",
-                    'momentum_icon': "📊",
+                    'momentum_icon': "",
                     'momentum_color': "#64748B",
                     'year_over_year_change': 0,
                     'improved_measures': [],
@@ -156,7 +156,7 @@ class TSMAnalytics:
                 return {
                     'direction': "no_comparison",
                     'momentum_text': "No comparable measures",
-                    'momentum_icon': "📊",
+                    'momentum_icon': "",
                     'momentum_color': "#64748B",
                     'year_over_year_change': 0,
                     'improved_measures': [],
@@ -214,7 +214,7 @@ class TSMAnalytics:
             return {
                 'direction': "error",
                 'momentum_text': f"Error: {str(e)}",
-                'momentum_icon': "⚠️",
+                'momentum_icon': "",
                 'momentum_color': "#64748B",
                 'year_over_year_change': 0,
                 'improved_measures': [],

--- a/app.py
+++ b/app.py
@@ -37,7 +37,7 @@ if _sentry_dsn:
 # Using 'wide' layout for all devices, content adapts responsively
 st.set_page_config(
     page_title="HAILIE TSM Insights Engine",
-    page_icon="✓",
+    page_icon=None,
     layout="wide",
     initial_sidebar_state="collapsed"
 )
@@ -98,13 +98,13 @@ def render_features_overview():
         st.markdown("### Key Insights We Provide")
         
         with st.container():
-            st.markdown("**📊 Your Rank**")
+            st.markdown("**Your Rank**")
             st.markdown("See exactly how your housing provider compares to peers with quartile-based scoring.")
-            
-            st.markdown("**📈 Your Momentum**")
+
+            st.markdown("**Your Momentum**")
             st.markdown("Track your 12-month performance trajectory across key satisfaction measures.")
-            
-            st.markdown("**🎯 Your Priority**")
+
+            st.markdown("**Your Priority**")
             st.markdown("Identify the single most critical area for improvement based on data-driven analysis.")
     else:
         # Desktop version - use custom HTML grid
@@ -149,7 +149,7 @@ def check_database_exists():
 
     # Check if file is readable
     if not os.access(db_path, os.R_OK):
-        st.error(f"❌ Database file exists but is not readable: {db_path}")
+        st.error(f"Database file exists but is not readable: {db_path}")
         return False
 
     # Check if it's a valid DuckDB file (basic check)
@@ -160,7 +160,7 @@ def check_database_exists():
         conn.close()
         return True
     except Exception as e:
-        st.error(f"❌ Database file exists but appears corrupted: {str(e)}")
+        st.error(f"Database file exists but appears corrupted: {str(e)}")
         return False
 
 
@@ -184,7 +184,7 @@ def render_dataset_indicator(dataset_type: str, peer_count: int):
         <strong style="color: {color};">Dataset: {dataset_type}</strong><br/>
         <small>{description}</small><br/>
         <small style="opacity: 0.8;">{note}</small><br/>
-        <small style="opacity: 0.8;">📊 Comparing with {peer_count} peer providers in {dataset_type} group</small>
+        <small style="opacity: 0.8;">Comparing with {peer_count} peer providers in {dataset_type} group</small>
     </div>
     """, unsafe_allow_html=True)
 
@@ -199,7 +199,7 @@ def main():
     # Check if database exists
     if not check_database_exists():
         st.error("""
-        ❌ **Enhanced Analytics Database Not Found**
+        **Enhanced Analytics Database Not Found**
 
         The enhanced analytics database with LCRA/LCHO separation has not been generated yet.
         Please run the enhanced ETL pipeline first:
@@ -221,7 +221,7 @@ def main():
         provider_options = data_processor_for_options.get_provider_options()
     except ConnectionError as e:
         st.error(f"""
-        ❌ **Database Connection Failed**
+        **Database Connection Failed**
 
         Unable to connect to the analytics database: {str(e)}
 
@@ -235,7 +235,7 @@ def main():
         """)
         return
     except Exception as e:
-        st.error(f"❌ Unexpected error initializing data processor: {str(e)}")
+        st.error(f"Unexpected error initializing data processor: {str(e)}")
         return
 
     provider_code = None
@@ -246,7 +246,7 @@ def main():
         # Device view toggle
         st.header("View Settings")
         force_mobile = st.checkbox(
-            "📱 Use Mobile View",
+            "Use Mobile View",
             value=detect_mobile(),
             help="Toggle mobile-optimized layout"
         )
@@ -266,7 +266,7 @@ def main():
 
         # Note about dataset separation
         st.info("""
-        🔄 **Automatic Dataset Detection**
+        **Automatic Dataset Detection**
 
         The system automatically detects whether your selected provider 
         belongs to the LCRA or LCHO dataset and compares only with 
@@ -286,7 +286,7 @@ def main():
         # Note about the enhanced architecture
         st.markdown("---")
         st.info(f"""
-        📊 **Enhanced Analytics Engine**
+        **Enhanced Analytics Engine**
 
         This application uses an enhanced analytics database with:
         • Separate LCRA and LCHO datasets
@@ -327,7 +327,7 @@ def main():
             selected_provider = None
             provider_name_only = None
     else:
-        st.error("❌ Unable to load provider list. Please try refreshing the page.")
+        st.error("Unable to load provider list. Please try refreshing the page.")
         provider_code = None
         selected_provider = None
         provider_name_only = None
@@ -341,7 +341,7 @@ def main():
             data_processor = EnhancedTSMDataProcessor(silent_mode=not show_advanced_logging)
         except ConnectionError as e:
             st.error(f"""
-            ❌ **Database Connection Failed**
+            **Database Connection Failed**
 
             Unable to connect to the analytics database: {str(e)}
 
@@ -349,18 +349,18 @@ def main():
             """)
             return
         except Exception as e:
-            st.error(f"❌ Unexpected error: {str(e)}")
+            st.error(f"Unexpected error: {str(e)}")
             return
 
         # Check if provider exists in database
         if not data_processor.get_provider_exists(provider_code):
-            st.error(f"❌ Provider '{provider_code}' not found. Please check the code and try again.")
+            st.error(f"Provider '{provider_code}' not found. Please check the code and try again.")
             return
 
         # Get the dataset type for this provider (use the name without the code part)
         dataset_type = data_processor.get_provider_dataset_type(provider_code, provider_name_only)
         if not dataset_type:
-            st.error(f"❌ Could not determine dataset type for provider '{provider_code}'")
+            st.error(f"Could not determine dataset type for provider '{provider_code}'")
             return
 
         # Get dataset summary stats for context
@@ -374,10 +374,10 @@ def main():
         df = data_processor.load_default_data(provider_code, provider_name_only)
 
         if df is None or df.empty:
-            st.error("❌ Unable to load provider data. Please try again later.")
+            st.error("Unable to load provider data. Please try again later.")
             return
 
-        st.success(f"✅ Loaded {dataset_type} analytics for provider: {provider_code}")
+        st.success(f"Loaded {dataset_type} analytics for provider: {provider_code}")
 
         # Dismissible changelog toast — appears once per session for returning users
         if 'dismissed_changelog' not in st.session_state:
@@ -434,13 +434,13 @@ def main():
             st.markdown("---")
             st.markdown("## Detailed Analysis")
             
-            with st.expander("📊 Performance Analysis", expanded=True):
+            with st.expander("Performance Analysis", expanded=True):
                 st.markdown(f"### Performance Analysis - {dataset_type} Peer Group")
 
                 # Show note for LCHO providers about missing metrics
                 if dataset_type == 'LCHO':
                     st.info("""
-                    ℹ️ **Note for LCHO Providers**: 
+                    **Note for LCHO Providers**:
                     Repairs metrics (TP02-TP04) are not applicable to LCHO providers 
                     and are excluded from this analysis. All comparisons are made 
                     within your LCHO peer group only.
@@ -474,7 +474,7 @@ def main():
                 else:
                     dashboard.render_performance_analysis(detailed_analysis)
 
-            with st.expander("📈 Measure Correlations", expanded=False):
+            with st.expander("Measure Correlations", expanded=False):
                 st.markdown(f"### Correlation Analysis - {dataset_type} Dataset")
 
                 # Get dataset-specific correlations
@@ -487,7 +487,7 @@ def main():
 
                 dashboard.render_correlation_analysis(correlations, priority)
 
-            with st.expander("🎯 Priority Matrix", expanded=False):
+            with st.expander("Priority Matrix", expanded=False):
                 st.markdown(f"### Priority Matrix - {dataset_type} Context")
 
                 # Filter priority matrix for LCHO if needed
@@ -498,7 +498,7 @@ def main():
 
                 dashboard.render_priority_matrix(priority, detailed_analysis)
 
-            with st.expander("📋 Score Breakdown", expanded=False):
+            with st.expander("Score Breakdown", expanded=False):
                 st.markdown(f"### Your TSM Scores — {dataset_type}")
 
                 scores_df = data_processor.get_provider_scores(provider_code, dataset_type=dataset_type)
@@ -512,7 +512,7 @@ def main():
                         if dataset_type == 'LCHO':
                             scores_df = scores_df[~scores_df['tp_measure'].isin(LCHO_EXCLUDED)]
 
-                            st.info("ℹ️ **Note**: Measures TP02-TP04 (repairs and home-maintenance) are not applicable to LCHO providers and are excluded from this view.")
+                            st.info("**Note**: Measures TP02-TP04 (repairs and home-maintenance) are not applicable to LCHO providers and are excluded from this view.")
 
                         # Format for display
                         display_df = scores_df[['tp_measure', 'description', 'score']].copy()
@@ -548,7 +548,7 @@ def main():
             '/<a href="https://creativecommons.org/licenses/by/4.0/" style="color: #94A3B8;">CC-BY 4.0</a>.'
             '</p>'
             '<p style="text-align: center; font-size: 0.85em; color: #666; margin-top: 0.25rem;">'
-            '🔒 <a href="/privacy_policy" target="_self">Privacy Policy</a>'
+            '<a href="/privacy_policy" target="_self">Privacy Policy</a>'
             '</p>',
             unsafe_allow_html=True
         )
@@ -560,7 +560,7 @@ def main():
         # Instructions when no provider is selected
         st.markdown("---")
         st.info("""
-        👆 **Getting Started:**
+        **Getting Started:**
 
         Search for your provider name in the dropdown above.
         Start typing to filter the list and find your provider quickly.
@@ -578,7 +578,7 @@ def main():
             '/<a href="https://creativecommons.org/licenses/by/4.0/" style="color: #94A3B8;">CC-BY 4.0</a>.'
             '</p>'
             '<p style="text-align: center; font-size: 0.85em; color: #666; margin-top: 0.25rem;">'
-            '🔒 <a href="/privacy_policy" target="_self">Privacy Policy</a>'
+            '<a href="/privacy_policy" target="_self">Privacy Policy</a>'
             '</p>',
             unsafe_allow_html=True
         )

--- a/dashboard.py
+++ b/dashboard.py
@@ -108,7 +108,7 @@ class ExecutiveDashboard:
         with cols[0]:
             if is_mobile:
                 # Mobile: Use native Streamlit components
-                st.markdown("### 📊 YOUR RANK")
+                st.markdown("### YOUR RANK")
                 st.metric(
                     label="Position",
                     value=f"#{provider_ranking['rank']}",
@@ -153,7 +153,7 @@ class ExecutiveDashboard:
         with cols[1]:
             if is_mobile:
                 # Mobile: Use native Streamlit components
-                st.markdown("### 📈 YOUR MOMENTUM")
+                st.markdown("### YOUR MOMENTUM")
                 if momentum.get('disabled', False):
                     st.metric(
                         label="Trend",
@@ -281,7 +281,7 @@ class ExecutiveDashboard:
             
             if is_mobile:
                 # Mobile: Use native Streamlit components
-                st.markdown("### 🎯 YOUR PRIORITY")
+                st.markdown("### YOUR PRIORITY")
                 st.metric(
                     label=measure_code,
                     value=priority.get('priority_level', 'Medium'),
@@ -369,7 +369,7 @@ class ExecutiveDashboard:
             """)
 
         # Performance Comparison Section
-        with st.expander("📊 Performance Comparison", expanded=True):
+        with st.expander("Performance Comparison", expanded=True):
             # Create performance comparison chart
             if detailed_analysis:
                 measures = []
@@ -459,7 +459,7 @@ class ExecutiveDashboard:
                 st.table(table_df)
 
         # Correlation Analysis Section
-        with st.expander("📈 Correlation Analysis", expanded=False):
+        with st.expander("Correlation Analysis", expanded=False):
             # Add header with tooltip help
             col_header1, col_header2 = st.columns([4, 1])
             with col_header1:
@@ -594,7 +594,7 @@ class ExecutiveDashboard:
                 st.warning("Correlation analysis not available")
 
         # Priority Matrix Section
-        with st.expander("🎯 Priority Matrix", expanded=False):
+        with st.expander("Priority Matrix", expanded=False):
             # Add header with tooltip help
             col_header1, col_header2 = st.columns([4, 1])
             with col_header1:
@@ -697,8 +697,8 @@ class ExecutiveDashboard:
 
                     fig_matrix.update_layout(
                         title="Priority Matrix: Improvement Potential vs TP01 Correlation - Hover for Details",
-                        xaxis_title="Improvement Potential (%) →",
-                        yaxis_title="Relationship with Overall Satisfaction ↑",
+                        xaxis_title="Improvement Potential (%)",
+                        yaxis_title="Relationship with Overall Satisfaction",
                         height=600,
                         xaxis=dict(
                             range=[0, 100],

--- a/mobile_utils.py
+++ b/mobile_utils.py
@@ -162,7 +162,7 @@ def render_mobile_info():
     Render an info message for mobile users about limited functionality
     """
     st.info("""
-    📱 **Mobile View Activated**
+    **Mobile View Activated**
     
     You're viewing a simplified version optimized for mobile devices. 
     For full analytics including detailed charts, tables, and comprehensive reports, 

--- a/tooltip_definitions.py
+++ b/tooltip_definitions.py
@@ -154,7 +154,7 @@ class TooltipDefinitions:
                 • **3rd Quartile (Mid)**: Next 25% (below average)  
                 • **4th Quartile (Low)**: Bottom 25% of providers
                 
-                **Color coding**: Green (top) → Light Green → Orange → Red (bottom)
+                **Color coding**: Green (top), Light Green, Orange, Red (bottom)
                 """
             },
             'tp_measures': {


### PR DESCRIPTION
## Summary
Removes decorative glyphs from user-facing Python modules for a professional register consistent with the board-level housing audience. No semantic loss — every stripped emoji was ornamental next to its matching label text.

## Kept deliberately
- `analytics_refactored.py` lines 183/188/193 — the ↗️/↘️/→ momentum direction icons (load-bearing in the momentum card and tooltip legend).
- `styles.py` line 763 — CSS `content: "↗"` that matches the momentum arrow rendering.
- `tooltip_definitions.py` lines 48–50 — momentum-state legend that must match the icons above.

## Stripped
- Section markers (📊/📈/🎯/📋) on rank/momentum/priority/score cards.
- Error and success prefixes (❌/✅) — `st.error` / `st.success` already carry the visual cue via Streamlit's coloured banners.
- Info-note prefixes (ℹ️/🔄/📱/👆/🔒).
- Plotly axis-label arrows in `dashboard.py` (not momentum-semantic).
- Tooltip colour-legend separators (→ reduced to commas).
- Non-arrow `momentum_icon` values (`"📊"`/`"⚠️"`) set to `""` in the insufficient-data / no-comparable / error branches. Keeps dict shape intact for `dashboard.py`'s renderer which does `html.escape(str(momentum['momentum_icon']))`.
- `page_icon="✓"` → `page_icon=None`. The favicon can be set to the HAILIE logo in a follow-up; scoped out here to keep the diff boundary clean.

## Verification
```
python3 -c "import re, ...; pattern.findall(...)"
→ 7 glyph lines remain, all intentional (3 momentum_icon + 1 CSS + 3 tooltip legend)
```

## Test plan
- [x] Audit script confirms only intended glyphs remain
- [x] Syntax passes on all 6 files
- [x] `pre-commit` gitleaks hook passes
- [x] Local Streamlit smoke: section headers clean, error paths still read well without ❌, momentum card and tooltip still render arrows, mobile-view banner reads cleanly
- [ ] Post-deploy browser check on `https://insights.housingai.org` after batch merge with PRs #40 and the matrix-overlap fix

Generated with Claude Code