### PR TITLE
fix(dashboard): stagger priority-matrix label positions by quadrant (#36)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -24,6 +24,30 @@ def _corr_label(strength: float) -> str:
     return "Negligible"
 
 
+def _quadrant_label_positions(xs, ys, x_mid=50, y_mid=50):
+    """Per-point Plotly textposition array — labels pushed outward from the
+    quadrant centre AND staggered within each quadrant so clusters of 2–3
+    points at similar coords land at distinct vertical offsets instead of
+    all defaulting to the same position."""
+    # Each quadrant cycles through three vertical offsets on its outward side.
+    variants = {
+        ("top", "right"):    ("top right", "middle right", "bottom right"),
+        ("top", "left"):     ("top left", "middle left", "bottom left"),
+        ("bottom", "right"): ("bottom right", "middle right", "top right"),
+        ("bottom", "left"):  ("bottom left", "middle left", "top left"),
+    }
+    rank = {k: 0 for k in variants}
+    positions = []
+    for x, y in zip(xs, ys):
+        key = (
+            "top" if y >= y_mid else "bottom",
+            "right" if x >= x_mid else "left",
+        )
+        positions.append(variants[key][rank[key] % 3])
+        rank[key] += 1
+    return positions
+
+
 PLOTLY_LAYOUT = dict(
     font=dict(
         family='-apple-system, BlinkMacSystemFont, Inter, Segoe UI, sans-serif',
@@ -680,7 +704,10 @@ class ExecutiveDashboard:
                             line=dict(width=1, color='white')  # Add border for better visibility
                         ),
                         text=scatter_df['Measure'],
-                        textposition="top center",
+                        textposition=_quadrant_label_positions(
+                            scatter_df['Improvement Potential'],
+                            scatter_df['Correlation'],
+                        ),
                         hovertemplate="<b>%{text}</b><br>%{customdata}<extra></extra>",
                         customdata=matrix_hover_data
                     ))
@@ -998,7 +1025,7 @@ class ExecutiveDashboard:
                 y=y_values,
                 mode='markers+text',
                 text=labels,
-                textposition='top center',
+                textposition=_quadrant_label_positions(x_values, y_values),
                 marker=dict(
                     size=12,
                     color=colors,


### PR DESCRIPTION
## Summary
- Replaces `textposition='top center'` (static) on both priority-matrix scatter plots in `dashboard.py` with a per-point helper `_quadrant_label_positions` that:
  - Pushes each label outward from the quadrant centre (points in the top-right get labels top-right, etc.).
  - Staggers labels within each quadrant by cycling through top/middle/bottom variants, so up to 3 near-identical points land at distinct vertical offsets.
- Helper is module-level alongside `_corr_label` and shared by both renderers (`render_detailed_analysis` inner matrix and `render_priority_matrix`).

## Honest limitation
Smoke-testing showed that for tight clusters the labels can still overlap. The 3-way stagger helps only when points don't sit at nearly identical coords. A real collision-avoidance pass would need either:
- A force-directed label-placement algorithm (iteratively nudging labels based on pairwise distance), or
- A client-side (JS) solver hooked into Plotly via a custom extension.

Both are out of scope for this PR. **Leaving issue #36 open** so the structural fix ships now and a more complete solution can follow.

## Test plan
- [x] `python3 -c "import ast; ast.parse(open('dashboard.py').read())"` — syntax passes
- [x] Helper unit-checked against 12-point test set — labels cycle correctly across all 4 quadrants
- [x] Local Streamlit smoke: labels now push outward; within-quadrant clusters improved but not fully resolved
- [x] pre-commit gitleaks hook passes

Generated with Claude Code