### PR TITLE
fix(security): suppress exception leaks and harden layer boundaries

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -98,3 +98,40 @@ When new government TSM data is published (typically November each year):
 ## Architecture Reference
 
 See `ADRs/ADR-004-migration-replit-to-railway.md` for the full decision record on this deployment architecture.
+
+## Security & Availability
+
+### Internal exceptions are never shown to users
+
+The runtime app (`app.py`, `dashboard.py`, `data_processor_enhanced.py`) follows a strict rule: raw exception messages, stack traces, and internal file paths never reach the browser. User-facing errors are short, generic, and actionable (e.g. "Database is unavailable. Please contact support.", "Try another provider or refresh.").
+
+Diagnostic details are routed through a private `_report_internal_error()` helper in each module, which writes to stdout and — when `SENTRY_DSN` is set — calls `sentry_sdk.capture_exception()`. The data layer never imports `streamlit`; it returns neutral values (`None`, empty `DataFrame`, `{}`) on failure and lets the UI layer decide what the user sees.
+
+If you add new exception handling, follow the same pattern: generic `st.error(...)` string + `_report_internal_error("<context>", exc)` call. Never interpolate `str(e)`, dict `['error']` payloads, or path variables into user-visible markdown.
+
+### Edge protection for public exposure
+
+Railway does not provide a Web Application Firewall. If the app is exposed to the public internet, front it with an edge layer that provides:
+
+- **Authentication / access control** — SSO, IP allowlist, or basic-auth gateway. Cloudflare Access, a reverse proxy with OAuth, or similar.
+- **TLS termination** — Railway provides TLS for the `*.railway.app` hostname, but custom domains must be configured correctly.
+- **Bot mitigation** — Cloudflare's managed challenge, or equivalent, to block scraping of the provider dropdown.
+
+If the app is intended for authenticated internal use only, put it behind a VPN or organisation-SSO gateway rather than relying on obscurity.
+
+### Rate limiting & bot mitigation
+
+Streamlit has no built-in rate limiting. Apply ingress-level controls at whichever layer fronts Railway:
+
+- **Cloudflare rate-limiting rules** — 100 requests/min/IP is a sensible starting point for a dashboard of this shape.
+- **Bot Fight Mode** (Cloudflare) or equivalent to reduce automated traffic.
+- Consider per-endpoint caps on `/_stcore/` health and websocket endpoints if you see abnormal traffic.
+
+### Replica guidance
+
+`railway.toml` sets `numReplicas = 2` as the baseline. This gives:
+
+- **Zero-downtime deploys** — one replica serves traffic while the other is rolling.
+- **Crash tolerance** — a single-replica crash (segfault, OOM, hung event loop) takes the service fully offline; two replicas buy you time to auto-restart.
+
+Scale above `2` if traffic justifies it (>50 concurrent users, noticeable latency). Above `4` consider a proper load-balancer health strategy and sticky sessions, since Streamlit websocket state is per-replica and not shared.

--- a/app.py
+++ b/app.py
@@ -9,10 +9,10 @@ from analytics_refactored import TSMAnalytics
 from dashboard import ExecutiveDashboard
 from styles import apply_css
 from mobile_utils import detect_mobile, mobile_friendly_columns, render_mobile_info, should_show_component
-import traceback
 from contextlib import contextmanager
 from config import DB_PATH
 from tsm_measures import LCHO_EXCLUDED
+import html
 import os
 
 # User-facing year label for the currently-loaded TSM dataset.
@@ -50,6 +50,17 @@ st.logo(
 
 # Apply custom CSS styles from styles module
 apply_css(st)
+
+
+def _report_internal_error(context: str, exc: Exception | None = None) -> None:
+    """Route error details to Sentry/stdout only — never to the UI."""
+    if exc is not None:
+        print(f"[ERROR] {context}: {type(exc).__name__}")
+    else:
+        print(f"[ERROR] {context}")
+    if _sentry_dsn and exc is not None:
+        import sentry_sdk
+        sentry_sdk.capture_exception(exc)
 
 
 def render_landing_hero():
@@ -155,7 +166,8 @@ def check_database_exists():
 
     # Check if file is readable
     if not os.access(db_path, os.R_OK):
-        st.error(f"Database file exists but is not readable: {db_path}")
+        _report_internal_error("database file exists but is not readable")
+        st.error("Database is unavailable. Please contact support.")
         return False
 
     # Check if it's a valid DuckDB file (basic check)
@@ -166,7 +178,8 @@ def check_database_exists():
         conn.close()
         return True
     except Exception as e:
-        st.error(f"Database file exists but appears corrupted: {str(e)}")
+        _report_internal_error("database corruption check failed", e)
+        st.error("Database is unavailable. Please contact support.")
         return False
 
 
@@ -185,12 +198,17 @@ def render_dataset_indicator(dataset_type: str, peer_count: int):
         description = "Combined Dataset"
         note = "Providers with combined reporting"
 
+    safe_dataset = html.escape(dataset_type)
+    safe_description = html.escape(description)
+    safe_note = html.escape(note)
+    safe_peer_count = html.escape(str(peer_count))
+
     st.markdown(f"""
     <div style="background-color: {color}15; border-left: 4px solid {color}; padding: 10px; margin: 10px 0; border-radius: 4px;">
-        <strong style="color: {color};">Dataset: {dataset_type}</strong><br/>
-        <small>{description}</small><br/>
-        <small style="opacity: 0.8;">{note}</small><br/>
-        <small style="opacity: 0.8;">Comparing with {peer_count} peer providers in {dataset_type} group</small>
+        <strong style="color: {color};">Dataset: {safe_dataset}</strong><br/>
+        <small>{safe_description}</small><br/>
+        <small style="opacity: 0.8;">{safe_note}</small><br/>
+        <small style="opacity: 0.8;">Comparing with {safe_peer_count} peer providers in {safe_dataset} group</small>
     </div>
     """, unsafe_allow_html=True)
 
@@ -226,22 +244,21 @@ def main():
         data_processor_for_options = EnhancedTSMDataProcessor(silent_mode=True)
         provider_options = data_processor_for_options.get_provider_options()
     except ConnectionError as e:
-        st.error(f"""
+        _report_internal_error("processor init: ConnectionError", e)
+        st.error("""
         **Database Connection Failed**
 
-        Unable to connect to the analytics database: {str(e)}
+        Unable to connect to the analytics database.
 
-        Please ensure the database file exists at:
-        `{DB_PATH}`
-
-        If the database is missing, run:
+        If you're running locally and the database is missing, run:
         ```bash
         python build_analytics_db_v2.py
         ```
         """)
         return
     except Exception as e:
-        st.error(f"Unexpected error initializing data processor: {str(e)}")
+        _report_internal_error("processor init: unexpected error", e)
+        st.error("Something went wrong starting the application. Please contact support.")
         return
 
     provider_code = None
@@ -346,16 +363,12 @@ def main():
         try:
             data_processor = EnhancedTSMDataProcessor(silent_mode=not show_advanced_logging)
         except ConnectionError as e:
-            st.error(f"""
-            **Database Connection Failed**
-
-            Unable to connect to the analytics database: {str(e)}
-
-            The database file may be corrupted or inaccessible.
-            """)
+            _report_internal_error("per-provider processor init: ConnectionError", e)
+            st.error("Database is unavailable. Please try again later or contact support.")
             return
         except Exception as e:
-            st.error(f"Unexpected error: {str(e)}")
+            _report_internal_error("per-provider processor init: unexpected error", e)
+            st.error("Something went wrong loading your provider. Please try another provider or refresh.")
             return
 
         # Check if provider exists in database

--- a/config.py
+++ b/config.py
@@ -22,9 +22,14 @@ DB_PATH = os.path.join(DATA_DIR, "hailie_analytics_v2.duckdb")
 SOURCE_DIR = os.path.join(DATA_DIR, "source")
 
 # Auto-seed: if DATA_PATH is set (persistent volume) but the database isn't there yet,
-# copy it from the baked-in image so the app works on first deploy.
+# copy it from the baked-in image so the app works on first deploy. Failures are
+# logged to stdout only — never raised at import, so the app can still start and
+# surface a controlled "database unavailable" message to the user.
 if DATA_DIR != _BAKED_IN_DATA and not os.path.exists(DB_PATH):
     _baked_db = os.path.join(_BAKED_IN_DATA, "hailie_analytics_v2.duckdb")
     if os.path.exists(_baked_db):
-        os.makedirs(DATA_DIR, exist_ok=True)
-        shutil.copy2(_baked_db, DB_PATH)
+        try:
+            os.makedirs(DATA_DIR, exist_ok=True)
+            shutil.copy2(_baked_db, DB_PATH)
+        except OSError as _seed_exc:
+            print(f"[ERROR] config auto-seed failed: {type(_seed_exc).__name__}")

--- a/dashboard.py
+++ b/dashboard.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2025-2026 Tom Stephenson (Teev-dev)
 
 import html
+import os
 import streamlit as st
 import pandas as pd
 import numpy as np
@@ -10,6 +11,17 @@ import plotly.graph_objects as go
 from typing import Dict, Any
 from tooltip_definitions import TooltipDefinitions
 from mobile_utils import detect_mobile, mobile_friendly_columns, should_show_component
+
+
+def _report_internal_error(context: str, payload: Any = None) -> None:
+    """Route error details to Sentry/stdout only — never to the UI."""
+    if payload is not None:
+        print(f"[ERROR] {context}: {payload!r}")
+    else:
+        print(f"[ERROR] {context}")
+    if os.environ.get("SENTRY_DSN") and isinstance(payload, BaseException):
+        import sentry_sdk
+        sentry_sdk.capture_exception(payload)
 
 
 def _corr_label(strength: float) -> str:
@@ -103,15 +115,18 @@ class ExecutiveDashboard:
 
         # Check for errors
         if "error" in rankings:
-            st.error(f"Rankings Error: {rankings['error']}")
+            _report_internal_error("rankings error", rankings.get("error"))
+            st.error("We couldn't calculate your rank right now. Try another provider or refresh.")
             return
 
         if "error" in momentum:
-            st.error(f"Momentum Error: {momentum['error']}")
+            _report_internal_error("momentum error", momentum.get("error"))
+            st.error("Momentum data is unavailable right now. Please try again later.")
             return
 
         if "error" in priority:
-            st.error(f"Priority Error: {priority['error']}")
+            _report_internal_error("priority error", priority.get("error"))
+            st.error("We couldn't identify a priority measure. Try another provider or refresh.")
             return
 
         # Get provider data
@@ -375,7 +390,8 @@ class ExecutiveDashboard:
         priority_data = analytics.identify_priority(df, provider_code)
 
         if "error" in detailed_analysis:
-            st.error(detailed_analysis["error"])
+            _report_internal_error("detailed analysis error", detailed_analysis.get("error"))
+            st.error("Detailed analysis is unavailable right now. Try another provider or refresh.")
             return
 
         # Add help information for the detailed analysis section
@@ -866,7 +882,8 @@ class ExecutiveDashboard:
             return
 
         if "error" in detailed_analysis:
-            st.error(detailed_analysis["error"])
+            _report_internal_error("performance analysis error", detailed_analysis.get("error"))
+            st.error("Performance analysis is unavailable right now. Try another provider or refresh.")
             return
 
         if detailed_analysis and len(detailed_analysis) > 0:
@@ -990,7 +1007,8 @@ class ExecutiveDashboard:
         st.markdown("### Priority Matrix")
 
         if "error" in priority:
-            st.error(priority["error"])
+            _report_internal_error("priority matrix error", priority.get("error"))
+            st.error("Priority matrix is unavailable right now. Try another provider or refresh.")
             return
 
         # Extract priorities if available

--- a/data_processor_enhanced.py
+++ b/data_processor_enhanced.py
@@ -6,19 +6,37 @@ Enhanced Data Processor for HAILIE Analytics with LCRA/LCHO Dataset Separation
 Handles automatic dataset detection and isolated peer comparisons
 """
 
-import streamlit as st
+import os
 import pandas as pd
 import duckdb
 import numpy as np
-from typing import Optional, Dict, List, Tuple
+from typing import Any, Optional, Dict, List, Tuple
 from config import DB_PATH
 from tsm_measures import TP_CODES, TP_DESCRIPTIONS, LCHO_EXCLUDED
+
+
+def _report_internal_error(context: str, payload: Any = None) -> None:
+    """Route error details to Sentry/stdout only — never to the UI.
+
+    The data layer must not render Streamlit UI; callers in app.py / dashboard.py
+    decide what the user sees. See CLAUDE.md "Layer Boundaries".
+    """
+    if payload is not None:
+        print(f"[ERROR] {context}: {payload!r}")
+    else:
+        print(f"[ERROR] {context}")
+    if os.environ.get("SENTRY_DSN") and isinstance(payload, BaseException):
+        import sentry_sdk
+        sentry_sdk.capture_exception(payload)
 
 
 class EnhancedTSMDataProcessor:
     """Enhanced processor for TSM data with dataset isolation"""
 
     def __init__(self, silent_mode=False):
+        # silent_mode is accepted for API compatibility but is now a no-op:
+        # the data layer never renders UI or emits console noise regardless.
+        # All diagnostics route through _report_internal_error.
         self.tp_codes = list(TP_CODES)
         self.tp_descriptions = dict(TP_DESCRIPTIONS)
         self.db_path = DB_PATH
@@ -30,19 +48,10 @@ class EnhancedTSMDataProcessor:
         """Connect to the enhanced DuckDB database"""
         try:
             self._connection = duckdb.connect(self.db_path, read_only=True)
-            if not self.silent_mode:
-                st.success("✅ Connected to enhanced analytics database")
         except Exception as e:
-            # Always log connection failures, even in silent mode
-            error_msg = f"❌ Failed to connect to database: {str(e)}"
-            if not self.silent_mode:
-                st.error(error_msg)
-            else:
-                # In silent mode, at least print to console for debugging
-                print(error_msg)
+            _report_internal_error("db connect failed", e)
             self._connection = None
-            # Raise exception to prevent the app from continuing with null connection
-            raise ConnectionError(f"Database connection failed: {str(e)}")
+            raise ConnectionError("Database connection failed") from e
 
     def _ensure_connection(self):
         """Ensure database connection is active, reconnect if needed"""
@@ -53,24 +62,17 @@ class EnhancedTSMDataProcessor:
             try:
                 self._connection.execute("SELECT 1").fetchone()
             except Exception as e:
-                # Connection is dead, reconnect
-                error_msg = f"⚠️ Database connection lost, attempting to reconnect: {str(e)}"
-                if not self.silent_mode:
-                    st.warning(error_msg)
-                else:
-                    print(error_msg)
+                _report_internal_error("db connection lost, reconnecting", e)
                 self._connection = None
                 self._connect_to_db()
 
     def _log_info(self, message):
-        """Log info message"""
-        if not self.silent_mode:
-            st.info(message)
+        """Deprecated no-op — kept for internal call-site stability."""
+        return
 
     def _log_error(self, message):
-        """Log error message"""
-        if not self.silent_mode:
-            st.error(message)
+        """Route internal diagnostics to the stdout/Sentry pipeline."""
+        _report_internal_error(str(message))
 
     def get_provider_dataset_type(self, provider_code: str, provider_name: Optional[str] = None) -> Optional[str]:
         """
@@ -181,8 +183,7 @@ class EnhancedTSMDataProcessor:
 
             return result[0] > 0 if result else False
         except Exception as e:
-            if not self.silent_mode:
-                st.error(f"Error checking provider existence: {str(e)}")
+            _report_internal_error("checking provider existence", e)
             return False
 
     def get_all_provider_codes(self) -> List[Dict[str, str]]:
@@ -411,16 +412,10 @@ class EnhancedTSMDataProcessor:
             if not isinstance(df, pd.DataFrame):
                 return pd.DataFrame()
 
-            # Log dataset-specific counts for debugging
-            if dataset_type and not self.silent_mode:
-                st.info(f"📊 Found {len(df)} providers in {dataset_type} dataset for rankings")
-
             return df
 
         except Exception as e:
-            self._log_error(f"Error fetching providers with scores: {str(e)}")
-            if not self.silent_mode:
-                st.error(f"Debug: Query failed - {str(e)}")
+            _report_internal_error("fetching providers with scores", e)
             return pd.DataFrame()
 
     def get_applicable_measures(self, dataset_type: str) -> List[str]:
@@ -462,16 +457,10 @@ class EnhancedTSMDataProcessor:
                 result['loaded_dataset'] = dataset_type
                 result['applicable_measures'] = [self.get_applicable_measures(dataset_type)]
 
-                # Log dataset info
-                if not self.silent_mode:
-                    st.info(f"📊 Loaded {dataset_type} data for provider {provider_code}")
-                    if dataset_type == 'LCHO':
-                        st.info("ℹ️ Note: Repairs metrics (TP02-TP04) are not applicable for LCHO providers")
-
                 return result
             return None
         except Exception as e:
-            self._log_error(f"Error loading provider data: {str(e)}")
+            _report_internal_error("loading provider data", e)
             return None
 
     def close(self):
@@ -480,8 +469,7 @@ class EnhancedTSMDataProcessor:
             try:
                 self._connection.close()
             except Exception as e:
-                if not self.silent_mode:
-                    st.warning(f"⚠️ Error closing database connection: {str(e)}")
+                _report_internal_error("closing database connection", e)
             finally:
                 self._connection = None
 

--- a/mobile_utils.py
+++ b/mobile_utils.py
@@ -18,11 +18,17 @@ def detect_mobile():
     if hasattr(st.session_state, 'force_mobile_view'):
         return st.session_state.force_mobile_view
     
-    # Check for manual override via query params
+    # Check for manual override via query params.
+    # Only exact "true" / "false" are honoured — any other value is ignored so
+    # malformed input falls through to normal detection instead of silently
+    # coercing to False.
     query_params = st.query_params
     if 'mobile' in query_params:
-        override_value = query_params['mobile'].lower() == 'true'
-        return override_value
+        raw = query_params['mobile'].lower()
+        if raw == 'true':
+            return True
+        if raw == 'false':
+            return False
     
     # Initialize session state for mobile detection if not exists
     if 'is_mobile_device' not in st.session_state:
@@ -41,7 +47,13 @@ def detect_mobile():
             // Consider it mobile if user agent matches OR (touch + small screen)
             const mobile = isMobile || (hasTouch && smallScreen);
             
-            // Send result back to Streamlit
+            // Send result back to Streamlit.
+            // Target origin is '*' because the Streamlit components iframe has
+            // no reliable way to learn its parent origin at runtime. The payload
+            // here is a single boolean — no session tokens, provider data, or
+            // credentials — so the information-disclosure impact is nil. If a
+            // stricter target becomes supportable by the Streamlit component
+            // API, migrate this to that origin.
             if (window.parent) {
                 window.parent.postMessage({
                     type: 'streamlit:setComponentValue',

--- a/railway.toml
+++ b/railway.toml
@@ -3,7 +3,7 @@ builder = "DOCKERFILE"
 dockerfilePath = "Dockerfile"
 
 [deploy]
-numReplicas = 1
+numReplicas = 2
 healthcheckPath = "/_stcore/health"
 healthcheckTimeout = 10
 restartPolicyType = "ON_FAILURE"


### PR DESCRIPTION
## Summary

- Removes exception payload leaks from every user-facing `st.error()` site in `app.py`, `dashboard.py`, and `data_processor_enhanced.py`. Raw `str(e)`, dict `['error']` strings, and internal paths no longer reach the browser.
- Adds a private `_report_internal_error()` helper in each module that routes details to stdout and Sentry (when `SENTRY_DSN` is set).
- Restores the data/UI layer boundary: `data_processor_enhanced.py` no longer imports `streamlit` or calls any `st.*` UI function. Returns neutral values; the UI layer decides what users see.
- Escapes dynamic HTML in `render_dataset_indicator()` (dataset_type, description, note, peer_count) under `unsafe_allow_html=True`.
- Hardens `config.py` import-time auto-seed with `try/except` so Railway filesystem failures log to stdout instead of crashing module import.
- Tightens `mobile_utils.py` query param parsing (only exact `true`/`false` honoured; malformed values ignored) and documents the `postMessage("*")` rationale.
- Bumps `railway.toml` `numReplicas` from 1 → 2 for zero-downtime deploys.
- Adds a Security & Availability section to `DEPLOYMENT.md` covering the exception policy, edge protection, rate limiting, and replica guidance.

## Test plan

- [x] Static sweep: `grep "str(e)" *.py` returns no matches inside `st.error/warning/info/success` calls.
- [x] Static sweep: `grep "st.error|st.warning|st.info|st.success" data_processor_enhanced.py` returns zero hits.
- [x] Static sweep: `grep "\['error'\]|\[\"error\"\]" dashboard.py` returns zero hits.
- [x] Syntax check: `python -c "import ast; ..."` passes for all modified `.py` files.
- [x] Import check: all modules import cleanly; `data_processor_enhanced` no longer imports streamlit.
- [x] Pre-commit gitleaks: passed.
- [ ] Local run: `streamlit run app.py` — verify normal provider selection is visually unchanged.
- [ ] Local run: point `DATA_PATH` at a bad directory — confirm generic message appears, no path leak.
- [ ] Local run: query `?mobile=true`, `?mobile=false`, `?mobile=bogus` — confirm only the first two affect layout.
- [ ] Docker build: `docker build -t hailie-insights . && docker run -p 8501:8501 -e PORT=8501 hailie-insights` — confirm no runtime regressions.
- [ ] Sentry smoke test (if `SENTRY_DSN` set locally): force an error, confirm generic message in UI + full event in Sentry.

## Notes for reviewer

- The `silent_mode` parameter on `EnhancedTSMDataProcessor.__init__` is retained for API stability but is now a no-op — the data layer never renders UI or prints console noise regardless. A follow-up PR could remove the "Show advanced logging view" sidebar checkbox in `app.py`, which is now effectively inert.
- The 10 remaining `self._log_error(f"...{str(e)}")` call sites in `data_processor_enhanced.py` now route to `_report_internal_error` via the `_log_error` compatibility shim. They stringify the exception into the log line but don't pass the exception object to `sentry_sdk.capture_exception`. A follow-up could migrate each call site to `_report_internal_error(context, e)` directly for full Sentry traceback fidelity.
- Edge protection (SSO/WAF/rate limiting) is documented in `DEPLOYMENT.md` but is out-of-repo infra work — not implemented here.

Generated with Claude Code